### PR TITLE
Switch to use pipelines cluster pool

### DIFF
--- a/internal/prowgen/config.go
+++ b/internal/prowgen/config.go
@@ -326,8 +326,8 @@ func getClusterClaim(ocpVersion string) *cioperatorapi.ClusterClaim {
 	return &cioperatorapi.ClusterClaim{
 		Architecture: "amd64",
 		As:           "latest",
-		Cloud:        cioperatorapi.CloudAWS,
-		Owner:        "openshift-ci",
+		Cloud:        "psi-pipelines",
+		Owner:        "pipelines",
 		Product:      cioperatorapi.ReleaseProductOCP,
 		Timeout:      &prowv1.Duration{time.Duration(60) * time.Minute},
 		Version:      ocpVersion,


### PR DESCRIPTION
A follow up PR for https://github.com/openshift/release/pull/51872
This PR will replace the `openshift-ci` cluster pool with the created `pipelines` cluster pool