### PR TITLE
Use 1.21 in the task config yaml

### DIFF
--- a/config/task-buildpacks.yaml
+++ b/config/task-buildpacks.yaml
@@ -1,5 +1,5 @@
 repository: task-buildpacks
-golang: 1.20
+golang: 1.21
 openshift:
   version: 4.14
 openshift-pipelines:

--- a/config/task-containers.yaml
+++ b/config/task-containers.yaml
@@ -1,5 +1,5 @@
 repository: task-containers
-golang: 1.20
+golang: 1.21
 openshift:
   version: 4.14
 openshift-pipelines:

--- a/config/task-git.yaml
+++ b/config/task-git.yaml
@@ -1,5 +1,5 @@
 repository: task-git
-golang: 1.20
+golang: 1.21
 openshift:
   version: 4.14
 openshift-pipelines:

--- a/config/task-maven.yaml
+++ b/config/task-maven.yaml
@@ -1,5 +1,5 @@
 repository: task-maven
-golang: 1.20
+golang: 1.21
 openshift:
   version: 4.14
 openshift-pipelines:

--- a/config/task-openshift.yaml
+++ b/config/task-openshift.yaml
@@ -1,5 +1,5 @@
 repository: task-openshift
-golang: 1.20
+golang: 1.21
 openshift:
   version: 4.14
 openshift-pipelines:


### PR DESCRIPTION
Task config yaml was using older version of Golang. 
This PR aims to change the version to `1.21`