### PR TITLE
Switch back to go 1.20

### DIFF
--- a/config/task-buildpacks.yaml
+++ b/config/task-buildpacks.yaml
@@ -1,5 +1,5 @@
 repository: task-buildpacks
-golang: 1.21
+golang: 1.20
 openshift:
   version: 4.15
 openshift-pipelines:

--- a/config/task-containers.yaml
+++ b/config/task-containers.yaml
@@ -1,5 +1,5 @@
 repository: task-containers
-golang: 1.21
+golang: 1.20
 openshift:
   version: 4.15
 openshift-pipelines:

--- a/config/task-git.yaml
+++ b/config/task-git.yaml
@@ -1,5 +1,5 @@
 repository: task-git
-golang: 1.21
+golang: 1.20
 openshift:
   version: 4.15
 openshift-pipelines:

--- a/config/task-maven.yaml
+++ b/config/task-maven.yaml
@@ -1,5 +1,5 @@
 repository: task-maven
-golang: 1.21
+golang: 1.20
 openshift:
   version: 4.15
 openshift-pipelines:

--- a/config/task-openshift.yaml
+++ b/config/task-openshift.yaml
@@ -1,5 +1,5 @@
 repository: task-openshift
-golang: 1.21
+golang: 1.20
 openshift:
   version: 4.15
 openshift-pipelines:


### PR DESCRIPTION
This is required as there is no image available for go 1.20 and 4.15