### PR TITLE
remove target from release plan spec as its not required for the tenant release

### DIFF
--- a/cmd/konflux/templates/konflux/release-plan.yaml
+++ b/cmd/konflux/templates/konflux/release-plan.yaml
@@ -9,7 +9,6 @@ metadata:
   name: {{basename .Repository | hyphenize}}-{{hyphenize .Version}}-rp
 spec:
   application: {{.Name}}-{{hyphenize .Version}}
-  target: tekton-ecosystem-tenant
   tenantPipeline:
     serviceAccountName: release-registry-openshift-pipelines-next
     pipelineRef:


### PR DESCRIPTION
As per this doc https://konflux-ci.dev/docs/advanced-how-tos/releasing/tenant-release-pipelines/ we don't need to add `target` in spec
by removing the target from spec i see release pipeline got triggered 