### PR TITLE
Update EnterpriseContractPolicy for allowed_package_sources and allowed_registry_prefixes

### DIFF
--- a/cmd/konflux-apply/manifests/entreprise-contract-policy.yaml
+++ b/cmd/konflux-apply/manifests/entreprise-contract-policy.yaml
@@ -15,6 +15,11 @@ spec:
       policy:
         - oci::quay.io/enterprise-contract/ec-release-policy:git-96f77c3@sha256:7c8b7651786a042f4b1295d134b167b05001686574e947b51cd70a365fe3ad22
       ruleData:
+        allowed_package_sources:
+          # Allow  yq package to download from github
+          - key: https://github.com/mikefarah/yq/releases/download/v4.45.1
+            patterns: [.*]
+            type: generic
         allowed_registry_prefixes:
           # Default
           - registry.access.redhat.com/
@@ -22,6 +27,7 @@ spec:
           - brew.registry.redhat.io/rh-osbs/openshift-golang-builder
           # We may have a nudging relationship between components again
           - quay.io/redhat-user-workloads/tekton-ecosystem-tenant
+          - quay.io/openshift-pipeline
           # It's ok to build on konflux-ci images, because they are subject to this policy too.
           - quay.io/konflux-ci
       config:


### PR DESCRIPTION
https://github.com/mikefarah/yq/releases/download/v4.45.1 added in allowed_package_sources as we download yq binaries from here.

quay.io/openshift-pipeline is added in allowed_registry_prefixes as we publish nightly images into this repo.