### PR TITLE
Add auto for operator's nightly release

### DIFF
--- a/cmd/konflux/templates/konflux/tests-e2e-tektoncd-pipelines.yaml
+++ b/cmd/konflux/templates/konflux/tests-e2e-tektoncd-pipelines.yaml
@@ -1,0 +1,18 @@
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  name: {{.Name}}-{{hyphenize .Version}}-e2e-tektoncd-pipelines
+spec:
+  application: {{.Name}}-{{hyphenize .Version}}
+  contexts:
+    - description: Application testing
+      name: component_{{.Name}}-{{hyphenize .Version}}-bundle
+  resolverRef:
+    params:
+      - name: url
+        value: https://github.com/openshift-pipelines/operator
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .konflux/tekton/bundle-e2e-pipeline.yaml
+    resolver: git

--- a/cmd/konflux/templates/konflux/tests.yaml
+++ b/cmd/konflux/templates/konflux/tests.yaml
@@ -8,7 +8,7 @@ spec:
   application: {{.Name}}-{{hyphenize .Version}}
   contexts:
 {{- $name :=  .Name }}
-{{- $version :=  .Version }}
+{{- $version :=  hyphenize .Version }}
 {{- range $component := .Components }}
     - description: Application testing for {{$name}}-{{$version}}-{{$component}}
       name: component_{{$name}}-{{$version}}-{{$component}}

--- a/config/konflux/operator.yaml
+++ b/config/konflux/operator.yaml
@@ -45,5 +45,6 @@ github:
 branches:
 - version: next
   upstream: main
+  release: auto
 - upstream: release-v0.32.x
   version: "1.18"


### PR DESCRIPTION
This PR contains multiple changes.

1. Operator release is changed to auto 
2. have removed the  tests-on-push as we have converted the group tests to single component.
3. added a condition for operator bundle to be included in tests.
4. Generate e2e from hack itself