### PR TITLE
Revert "Don't generate multiplatform build for Bundle component"

### DIFF
--- a/cmd/konflux/templates/tekton/component-push.yaml
+++ b/cmd/konflux/templates/tekton/component-push.yaml
@@ -36,11 +36,6 @@ spec:
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/{{hyphenize .Version.Version}}/{{.ImagePrefix}}{{.Name}}{{.ImageSuffix}}:{{"{{revision}}"}}
   - name: dockerfile
     value: {{.Dockerfile}}
-  {{- if contains (printf "%s-%s-%s" (basename .Repository.Name | hyphenize) (hyphenize .Version.Version) .Name) "bundle" }}
-  - name: build-platforms
-    value:
-      - linux/x86_64
-  {{- end }}
   - name: prefetch-input
     value: |
       {{ .PrefetchInput }}


### PR DESCRIPTION
Reverts openshift-pipelines/hack#146