### PR TITLE
Don't generate multiplatform build for Bundle component

### DIFF
--- a/cmd/konflux/templates/tekton/component-push.yaml
+++ b/cmd/konflux/templates/tekton/component-push.yaml
@@ -36,6 +36,13 @@ spec:
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/{{hyphenize .Version}}/{{.ImagePrefix}}{{.Name}}{{.ImageSuffix}}:{{"{{revision}}"}}
   - name: dockerfile
     value: {{.Dockerfile}}
+  {{- if contains (printf "%s-%s-%s" (basename .Repository.Name | hyphenize) (hyphenize .Version.Version) .Name) "bundle" }}
+  - name: build-platforms
+    value:
+      - linux/x86_64
+  - name: build-image-index
+    value: false
+  {{- end }}    
   - name: prefetch-input
     value: |
       {{ .PrefetchInput }}


### PR DESCRIPTION
Now konflux added a policy to check whether bundle is multiarch or not if multiarch policy will fail

these are the changes they have suggested
```
How can I make the required change?

If you have a build pipeline that automatically creates an image index (i.e. docker-build-multi-platform-oci-ta), you will need to disable that with the following parameters in your PipelineRun.
Set the build-platforms parameter to have only a single value, i.e. linux/x86_64. [3]
Set the build-image-index parameter to "false". [4]
```

Updated push yaml accordingly