### PR TITLE
feat: add workflow to trigger image rebuilds across downstream repos

### DIFF
--- a/.github/workflows/trigger-image-rebuilds.yaml
+++ b/.github/workflows/trigger-image-rebuilds.yaml
@@ -29,7 +29,11 @@ jobs:
 
       - name: Install yq
         run: |
-          sudo wget -q https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+          YQ_VERSION="v4.52.4"
+          YQ_SHA256="0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c"
+          wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
+          echo "$YQ_SHA256  /tmp/yq" | sha256sum --check --strict
+          sudo mv /tmp/yq /usr/local/bin/yq
           sudo chmod +x /usr/local/bin/yq
 
       - name: Trigger rebuilds via .konflux/patches/.placeholder

--- a/.github/workflows/trigger-image-rebuilds.yaml
+++ b/.github/workflows/trigger-image-rebuilds.yaml
@@ -69,6 +69,7 @@ jobs:
           OK=0
           SKIPPED=0
           FAILED=0
+          RESULTS=""
 
           for REPO in $REPOS; do
             if [[ -n "$TARGET_REPO" ]] && [[ "$REPO" != "$TARGET_REPO" ]]; then
@@ -81,6 +82,7 @@ jobs:
             # Check if branch exists
             if ! gh api "repos/$FULL_REPO/branches/$BRANCH" --silent 2>/dev/null; then
               echo "SKIP $REPO: branch $BRANCH not found"
+              RESULTS="${RESULTS}| ${REPO} | ${BRANCH} | Skipped (no branch) | - |\n"
               SKIPPED=$((SKIPPED + 1))
               continue
             fi
@@ -99,10 +101,13 @@ jobs:
               "${SHA_ARGS[@]}" \
               --field branch="$BRANCH" 2>&1; then
               echo "FAILED $REPO ($BRANCH)"
+              RESULTS="${RESULTS}| ${REPO} | ${BRANCH} | Failed | - |\n"
               FAILED=$((FAILED + 1))
               continue
             fi
+            COMMIT_URL="https://github.com/${FULL_REPO}/commits/${BRANCH}"
             echo "OK $REPO ($BRANCH)"
+            RESULTS="${RESULTS}| [${REPO}](${COMMIT_URL}) | ${BRANCH} | OK | [view](${COMMIT_URL}) |\n"
             OK=$((OK + 1))
           done
 
@@ -116,6 +121,19 @@ jobs:
 
           echo "---"
           echo "Summary: $TOTAL repos processed, $OK ok, $SKIPPED skipped, $FAILED failed"
+
+          # Write GitHub Step Summary
+          {
+            echo "## Trigger Image Rebuilds"
+            echo ""
+            echo "**Version:** ${VERSION} | **Branch:** ${BRANCH} | **Timestamp:** ${TIMESTAMP}"
+            echo ""
+            echo "| Repo | Branch | Status | Commit |"
+            echo "|------|--------|--------|--------|"
+            echo -e "$RESULTS"
+            echo ""
+            echo "**Total:** ${TOTAL} | **OK:** ${OK} | **Skipped:** ${SKIPPED} | **Failed:** ${FAILED}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ $FAILED -gt 0 ]]; then
             exit 1

--- a/.github/workflows/trigger-image-rebuilds.yaml
+++ b/.github/workflows/trigger-image-rebuilds.yaml
@@ -1,0 +1,100 @@
+name: Trigger Image Rebuilds
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Downstream release version (e.g., "1.15", "1.22", "next")'
+        required: true
+        type: string
+      repo:
+        description: 'Specific repo name to target (leave empty for all downstream repos)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-rebuilds:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout hack repo
+        uses: actions/checkout@v6
+
+      - name: Install yq
+        run: |
+          sudo wget -q https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Trigger rebuilds via .konflux/patches/.placeholder
+        env:
+          GH_TOKEN: ${{ secrets.OPENSHIFT_PIPELINES_ROBOT }}
+          VERSION: ${{ inputs.version }}
+          TARGET_REPO: ${{ inputs.repo }}
+        run: |
+          if [[ "$VERSION" == "next" ]]; then
+            BRANCH="main"
+          else
+            BRANCH="release-v${VERSION}.x"
+          fi
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          ORG="openshift-pipelines"
+          PLACEHOLDER_PATH=".konflux/patches/.placeholder"
+
+          echo "Triggering image rebuilds on branch: $BRANCH"
+          echo "Timestamp: $TIMESTAMP"
+          echo "---"
+
+          REPOS=$(yq -N e '.repo // .name' config/downstream/repos/*.yaml | sort -u)
+
+          TOTAL=0
+          UPDATED=0
+          CREATED=0
+          SKIPPED=0
+
+          for REPO in $REPOS; do
+            if [[ -n "$TARGET_REPO" ]] && [[ "$REPO" != "$TARGET_REPO" ]]; then
+              continue
+            fi
+
+            TOTAL=$((TOTAL + 1))
+            FULL_REPO="$ORG/$REPO"
+
+            # Check if branch exists
+            if ! gh api "repos/$FULL_REPO/branches/$BRANCH" --silent 2>/dev/null; then
+              echo "SKIP $REPO: branch $BRANCH not found"
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            # Check if .placeholder already exists on the target branch
+            EXISTING_SHA=$(gh api "repos/$FULL_REPO/contents/$PLACEHOLDER_PATH?ref=$BRANCH" --jq '.sha' 2>/dev/null || echo "")
+
+            CONTENT=$(echo -n "rebuild $TIMESTAMP" | base64)
+
+            if [[ -n "$EXISTING_SHA" ]]; then
+              # Update existing file
+              gh api -X PUT "repos/$FULL_REPO/contents/$PLACEHOLDER_PATH" \
+                --field message="rebuild: trigger image rebuild $TIMESTAMP" \
+                --field content="$CONTENT" \
+                --field sha="$EXISTING_SHA" \
+                --field branch="$BRANCH" \
+                --silent
+              echo "UPDATED $REPO ($BRANCH)"
+              UPDATED=$((UPDATED + 1))
+            else
+              # Create the file (GitHub API creates intermediate dirs automatically)
+              gh api -X PUT "repos/$FULL_REPO/contents/$PLACEHOLDER_PATH" \
+                --field message="rebuild: trigger image rebuild $TIMESTAMP" \
+                --field content="$CONTENT" \
+                --field branch="$BRANCH" \
+                --silent
+              echo "CREATED $REPO ($BRANCH)"
+              CREATED=$((CREATED + 1))
+            fi
+          done
+
+          echo "---"
+          echo "Summary: $TOTAL repos processed, $UPDATED updated, $CREATED created, $SKIPPED skipped"

--- a/.github/workflows/trigger-image-rebuilds.yaml
+++ b/.github/workflows/trigger-image-rebuilds.yaml
@@ -34,6 +34,14 @@ jobs:
           VERSION: ${{ inputs.version }}
           TARGET_REPO: ${{ inputs.repo }}
         run: |
+          set -euo pipefail
+
+          # Validate version format
+          if [[ ! "$VERSION" =~ ^(next|[0-9]+\.[0-9]+)$ ]]; then
+            echo "ERROR: Invalid version format '$VERSION'. Expected 'next' or 'X.Y' (e.g., '1.22')"
+            exit 1
+          fi
+
           if [[ "$VERSION" == "next" ]]; then
             BRANCH="main"
           else
@@ -95,6 +103,14 @@ jobs:
               CREATED=$((CREATED + 1))
             fi
           done
+
+          # Detect repo name typos
+          if [[ -n "$TARGET_REPO" ]] && [[ $TOTAL -eq 0 ]]; then
+            echo "ERROR: repo '$TARGET_REPO' not found in config/downstream/repos/*.yaml"
+            echo "Available repos:"
+            echo "$REPOS"
+            exit 1
+          fi
 
           echo "---"
           echo "Summary: $TOTAL repos processed, $UPDATED updated, $CREATED created, $SKIPPED skipped"

--- a/.github/workflows/trigger-image-rebuilds.yaml
+++ b/.github/workflows/trigger-image-rebuilds.yaml
@@ -13,6 +13,10 @@ on:
         type: string
         default: ''
 
+concurrency:
+  group: trigger-rebuilds-${{ inputs.version }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/trigger-image-rebuilds.yaml
+++ b/.github/workflows/trigger-image-rebuilds.yaml
@@ -58,9 +58,9 @@ jobs:
           REPOS=$(yq -N e '.repo // .name' config/downstream/repos/*.yaml | sort -u)
 
           TOTAL=0
-          UPDATED=0
-          CREATED=0
+          OK=0
           SKIPPED=0
+          FAILED=0
 
           for REPO in $REPOS; do
             if [[ -n "$TARGET_REPO" ]] && [[ "$REPO" != "$TARGET_REPO" ]]; then
@@ -80,28 +80,22 @@ jobs:
             # Check if .placeholder already exists on the target branch
             EXISTING_SHA=$(gh api "repos/$FULL_REPO/contents/$PLACEHOLDER_PATH?ref=$BRANCH" --jq '.sha' 2>/dev/null || echo "")
 
-            CONTENT=$(echo -n "rebuild $TIMESTAMP" | base64)
+            CONTENT=$(echo -n "rebuild $TIMESTAMP" | base64 -w 0)
 
-            if [[ -n "$EXISTING_SHA" ]]; then
-              # Update existing file
-              gh api -X PUT "repos/$FULL_REPO/contents/$PLACEHOLDER_PATH" \
-                --field message="rebuild: trigger image rebuild $TIMESTAMP" \
-                --field content="$CONTENT" \
-                --field sha="$EXISTING_SHA" \
-                --field branch="$BRANCH" \
-                --silent
-              echo "UPDATED $REPO ($BRANCH)"
-              UPDATED=$((UPDATED + 1))
-            else
-              # Create the file (GitHub API creates intermediate dirs automatically)
-              gh api -X PUT "repos/$FULL_REPO/contents/$PLACEHOLDER_PATH" \
-                --field message="rebuild: trigger image rebuild $TIMESTAMP" \
-                --field content="$CONTENT" \
-                --field branch="$BRANCH" \
-                --silent
-              echo "CREATED $REPO ($BRANCH)"
-              CREATED=$((CREATED + 1))
+            SHA_ARGS=()
+            [[ -n "$EXISTING_SHA" ]] && SHA_ARGS=(--field "sha=$EXISTING_SHA")
+
+            if ! gh api -X PUT "repos/$FULL_REPO/contents/$PLACEHOLDER_PATH" \
+              --field message="rebuild: trigger image rebuild $TIMESTAMP" \
+              --field content="$CONTENT" \
+              "${SHA_ARGS[@]}" \
+              --field branch="$BRANCH" 2>&1; then
+              echo "FAILED $REPO ($BRANCH)"
+              FAILED=$((FAILED + 1))
+              continue
             fi
+            echo "OK $REPO ($BRANCH)"
+            OK=$((OK + 1))
           done
 
           # Detect repo name typos
@@ -113,4 +107,8 @@ jobs:
           fi
 
           echo "---"
-          echo "Summary: $TOTAL repos processed, $UPDATED updated, $CREATED created, $SKIPPED skipped"
+          echo "Summary: $TOTAL repos processed, $OK ok, $SKIPPED skipped, $FAILED failed"
+
+          if [[ $FAILED -gt 0 ]]; then
+            exit 1
+          fi

--- a/.github/workflows/trigger-image-rebuilds.yaml
+++ b/.github/workflows/trigger-image-rebuilds.yaml
@@ -51,7 +51,7 @@ jobs:
           fi
 
           if [[ "$VERSION" == "next" ]]; then
-            BRANCH="main"
+            BRANCH="next"
           else
             BRANCH="release-v${VERSION}.x"
           fi


### PR DESCRIPTION
## Summary

- Adds a new manually-dispatched GitHub Actions workflow `trigger-image-rebuilds.yaml`
- Triggers Konflux image rebuilds by updating `.konflux/patches/.placeholder` in each downstream repo
- Creates the `.placeholder` file if it doesn't already exist in a repo
- Uses the GitHub Contents API to commit directly (same pattern as [tektoncd-results@e106311](https://github.com/openshift-pipelines/tektoncd-results/commit/e10631128987964409a94b8c987dd68be32ccb6e))

## Inputs

| Input | Required | Description |
|-------|----------|-------------|
| `version` | Yes | Release version (e.g., `1.15`, `1.22`, `next`) — maps to `release-v{version}.x` branch (`next` maps to `main`) |
| `repo` | No | Filter to a specific downstream repo name (empty = all repos) |

## How it works

1. Reads all downstream repo names from `config/downstream/repos/*.yaml`
2. For each repo, checks if the target branch exists
3. Checks if `.konflux/patches/.placeholder` exists on that branch
4. Creates or updates the file with `rebuild <timestamp>` content
5. The commit triggers Konflux to rebuild images

## Test plan

- [ ] Dispatch workflow with `version=1.15` and `repo=tektoncd-results` to test single-repo mode
- [ ] Verify the `.placeholder` file is updated and a Konflux build is triggered
- [ ] Dispatch with `version=1.15` and empty repo to test all-repos mode