### PR TITLE
Add dockerfiles in rennovate and  do not  login on github when dry-run

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
   ],
   "enabledManagers": [
     "tekton",
+    "dockerfile",
     "rpm-lockfile"
   ],
   "schedule": ["* * * * 0,6"],

--- a/.github/workflows/generate-konflux.yaml
+++ b/.github/workflows/generate-konflux.yaml
@@ -48,13 +48,17 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.25.x
-      - name: Generate  ${{matrix.version}} configurations and pull-requests
+      - name: login
+        if: github.event_name != 'pull_request'
         run: |
-          echo "Let's go"
           git config user.name openshift-pipelines-bot
           git config user.email pipelines-extcomm@redhat.com
           gh auth status
           gh auth setup-git
+
+      - name: Generate  ${{matrix.version}} configurations and pull-requests
+        run: |
+          echo "Let's go"
           go run ./cmd/konflux/ --version ${{ matrix.version }} --dry-run=${{ github.event_name == 'pull_request'}}
 
         env:


### PR DESCRIPTION
Updating renovate.json so that dockerfiles are updated
Removing login command from github workflow  its running for pull request as there is no commit involved