### PR TITLE
fix(config): resolvers component watches upstream

### DIFF
--- a/config/downstream/repos/tektoncd-pipeline.yaml
+++ b/config/downstream/repos/tektoncd-pipeline.yaml
@@ -8,7 +8,7 @@ components:
   - name: nop
   - name: resolvers
     tekton:
-      watched-sources: ("dependencies/tini/***".pathChanged() || ".konflux/patches/***".pathChanged() || ".konflux/rpms/***".pathChanged() )
+      watched-sources: ("dependencies/tini/***".pathChanged() || "upstream/***".pathChanged() || ".konflux/patches/***".pathChanged() || ".konflux/rpms/***".pathChanged() )
   - name: sidecarlogresults
   - name: webhook
   - name: workingdirinit


### PR DESCRIPTION
The resolvers component needs to be rebuilt any time the upstream code changes in addition to `dependencies/tini` and `konflux/**`

Before this change, the resolvers pipelineRuns were not running if the only change was to the upstream code. With this change, any change to the upstream code will trigger the resolvers pipelineruns be executed