### PR TITLE
feat(slack): add workflow failure notification for repos

### DIFF
--- a/cmd/konflux/main.go
+++ b/cmd/konflux/main.go
@@ -47,6 +47,12 @@ func main() {
 		log.Fatal(err)
 	}
 
+	config.Owners, err = readOwners(configDir)
+	if err != nil {
+		log.Printf("warning: could not read owners.yaml: %v", err)
+		config.Owners = map[string][]string{}
+	}
+
 	// Add main  version by default to add some main specific config.
 	versionConfig := k.ReleaseConfig{
 		Version: k.Release{
@@ -281,6 +287,9 @@ func readApplications(dir, applicationName string, versionConfig k.ReleaseConfig
 			if err != nil {
 				return []k.Application{}, err
 			}
+			if o, ok := config.Owners[repoName]; ok {
+				repo.Owners = o
+			}
 			application.Components = append(application.Components, repo.Components...)
 			application.Repositories = append(application.Repositories, repo)
 
@@ -406,4 +415,17 @@ func UpdateComponent(c *k.Component, repo k.Repository, app k.Application) error
 // readConfig reads the main konflux config file
 func readConfig(dir, configFile string) (k.Config, error) {
 	return readResource[k.Config](dir, "", configFile)
+}
+
+func readOwners(dir string) (map[string][]string, error) {
+	filePath := filepath.Join(dir, "owners.yaml")
+	in, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	var owners map[string][]string
+	if err := yaml.Unmarshal(in, &owners); err != nil {
+		return nil, fmt.Errorf("error while parsing owners %s: %w", filePath, err)
+	}
+	return owners, nil
 }

--- a/config/downstream/owners.yaml
+++ b/config/downstream/owners.yaml
@@ -1,0 +1,8 @@
+# Slack owners for repos (cc'd on workflow failure notifications).
+# Supports individual users and user groups.
+# Format:
+#   repo-name:
+#     - "<@SLACK_MEMBER_ID>"            # individual user (Profile > "..." > Copy member ID)
+#     - "<!subteam^SLACK_GROUP_ID>"     # user group (e.g. @team-name)
+tektoncd-cli:
+  - "<!subteam^S050DUBQXST>"

--- a/internal/konflux/config.go
+++ b/internal/konflux/config.go
@@ -5,10 +5,11 @@ type Config struct {
 	Namespace    string `yaml:"namespace"`
 	Applications []string
 	Versions     []string
-	Repositories []Repository `json:"repos" yaml:"repos"`
-	ImagePrefix  string       `json:"image-prefix" yaml:"image-prefix"`
-	ImageSuffix  string       `json:"image-suffix" yaml:"image-suffix"`
-	Product      string       `json:"product" yaml:"product"`
+	Repositories []Repository        `json:"repos" yaml:"repos"`
+	ImagePrefix  string              `json:"image-prefix" yaml:"image-prefix"`
+	ImageSuffix  string              `json:"image-suffix" yaml:"image-suffix"`
+	Product      string              `json:"product" yaml:"product"`
+	Owners       map[string][]string `json:"-" yaml:"-"`
 }
 
 type Application struct {
@@ -37,8 +38,9 @@ type Repository struct {
 	Tekton           Tekton
 	GitHub           GitHub
 	Patches          []Patch
-	NoPrefixUpstream bool `json:"no-prefix-upstream" yaml:"no-prefix-upstream"`
-	UsePatchBranch   bool `json:"use-patch-branch" yaml:"use-patch-branch"`
+	NoPrefixUpstream bool     `json:"no-prefix-upstream" yaml:"no-prefix-upstream"`
+	UsePatchBranch   bool     `json:"use-patch-branch" yaml:"use-patch-branch"`
+	Owners           []string `json:"owners" yaml:"owners"`
 }
 type Branch struct {
 	Name           string

--- a/internal/konflux/config_generator.go
+++ b/internal/konflux/config_generator.go
@@ -94,6 +94,12 @@ func generateGitHubConfig(repo Repository, targetDir string) error {
 		}
 		updateSourcesTemplateFile = "update-sources-all.yaml"
 		autoMergeTemplateFile = "auto-merge-upstream-all.yaml"
+
+		if len(repo.Owners) > 0 {
+			if err := generateFileFromTemplate("slack-notify-on-failure.yaml", repo, filepath.Join(target, "workflows", "slack-notify-on-failure.yaml"), repo.Application); err != nil {
+				return err
+			}
+		}
 	}
 
 	if repo.Upstream != "" {

--- a/internal/konflux/templates/github/workflows/slack-notify-on-failure.yaml
+++ b/internal/konflux/templates/github/workflows/slack-notify-on-failure.yaml
@@ -1,0 +1,75 @@
+name: Slack notification on workflow failure
+
+on:
+  workflow_run:
+    workflows: ["*"]
+    types: [completed]
+    branches:
+      - "main"
+      - "next"
+      - "nightly"
+      - "release-v*"
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: {{ "${{ github.event.workflow_run.conclusion == 'failure' }}" }}
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: {{ "${{ secrets.SLACK_WEBHOOK_URL }}" }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "GitHub Actions Workflow Failed"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Repository:*\n{{ "${{ github.event.workflow_run.repository.full_name }}" }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n{{ "${{ github.event.workflow_run.name }}" }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\n{{ "${{ github.event.workflow_run.head_branch }}" }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Triggered by:*\n{{ "${{ github.event.workflow_run.actor.login }}" }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "{{- range .Owners }} {{ . }}{{ end }} please check and fix."
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Run"
+                      },
+                      "url": "{{ "${{ github.event.workflow_run.html_url }}" }}"
+                    }
+                  ]
+                }
+              ]
+            }


### PR DESCRIPTION
Add a Slack notification workflow that alerts repo owners when GitHub Actions workflows fail. Owners are configured per-repo in owners.yaml with support for individual users and user groups. The workflow is generated only for main-branch repos that have owners defined.

Starting with tektoncd-cli for initial testing.


Assisted-by: Claude Opus 4 (via Cursor)