### PR TITLE
feat(slack): extend failure notifications to all repos

### DIFF
--- a/config/downstream/owners.yaml
+++ b/config/downstream/owners.yaml
@@ -4,5 +4,45 @@
 #   repo-name:
 #     - "<@SLACK_MEMBER_ID>"            # individual user (Profile > "..." > Copy member ID)
 #     - "<!subteam^SLACK_GROUP_ID>"     # user group (e.g. @team-name)
+
+# core
+git-init:
+  - "<!subteam^S04UX12MX8B>"
+manual-approval-gate:
+  - "<!subteam^S0B3NG4RH2Q>"
+pipelines-as-code:
+  - "<!subteam^S04FWV1N021>"
+tekton-caches:
+  - "<!subteam^S0B3JT5KR34>"
+tekton-kueue:
+  - "<!subteam^S0AS9T1JWHM>"
+tektoncd-chains:
+  - "<!subteam^S050DUERQ4X>"
+tektoncd-hub:
+  - "<!subteam^S050UAR1K8B>"
+tektoncd-pipeline:
+  - "<!subteam^S050DU2F7FH>"
+tektoncd-pruner:
+  - "<!subteam^S0B4D5U154G>"
+tektoncd-results:
+  - "<!subteam^S053P13TLDP>"
+tektoncd-triggers:
+  - "<!subteam^S051731DAM7>"
+syncer-service:
+  - "<!subteam^S0AS9T1JWHM>"
+multicluster-proxy-aae:
+  - "<!subteam^S0AS9T1JWHM>"
+console-plugin-pf5:
+  - "<!subteam^S075RLXAELT>"
+console-plugin:
+  - "<!subteam^S075RLXAELT>"
 tektoncd-cli:
   - "<!subteam^S050DUBQXST>"
+opc:
+  - "<!subteam^S050DUBQXST>"
+serve-tkn-cli:
+  - "<!subteam^S050DUBQXST>"
+operator:
+  - "<!subteam^S050WTYHHGU>"
+
+

--- a/internal/konflux/templates/github/workflows/slack-notify-on-failure.yaml
+++ b/internal/konflux/templates/github/workflows/slack-notify-on-failure.yaml
@@ -55,7 +55,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "{{- range .Owners }} {{ . }}{{ end }} please check and fix."
+                    "text": "{{- range .Owners }} {{ . }}{{ end }} please investigate and fix this failure.\nReach out to the release captain if you need assistance."
                   }
                 },
                 {


### PR DESCRIPTION
Populate owners.yaml with Slack group/member IDs for all downstream repos. Also update the notification message to guide owners toward the release captain for assistance.


Assisted-by: Claude Opus 4 (via Cursor)