### PR TITLE
Add Release Candidate build support to Release Automation scripts

### DIFF
--- a/.github/workflows/release-finalize-rc.yaml
+++ b/.github/workflows/release-finalize-rc.yaml
@@ -1,0 +1,24 @@
+name: Release Action - Finalize RC
+run-name: Finalize RC for version ${{ github.event.inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: |
+          Downstream Release Version. Eg: "1.22", "1.23"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  finalize-rc:
+    uses: ./.github/workflows/release-manager.yaml
+    with:
+      action: finalize-rc
+      version: ${{ github.event.inputs.version }}
+    secrets:
+      OPENSHIFT_PIPELINES_ROBOT: ${{ secrets.OPENSHIFT_PIPELINES_ROBOT }}

--- a/.github/workflows/release-manager.yaml
+++ b/.github/workflows/release-manager.yaml
@@ -1,9 +1,21 @@
 name: Automated Release Actions
-run-name: Execute ${{ github.event.inputs.action || 'update-upstream-versions' }} for version ${{ github.event.inputs.version || 'next' }}
+run-name: Execute ${{ inputs.action || 'update-upstream-versions' }} for version ${{ inputs.version || 'next' }}
 
 on:
-  schedule:
-    - cron: "0 0 * * *" # At every day at 00
+  workflow_call:
+    inputs:
+      action:
+        description: 'Select Action (see README for details)'
+        required: true
+        type: string
+      version:
+        description: |
+          Downstream Release Version. Eg: "1.22", "1.23", "next"
+        required: true
+        type: string
+    secrets:
+      OPENSHIFT_PIPELINES_ROBOT:
+        required: true
   workflow_dispatch:
     inputs:
       action:
@@ -13,22 +25,25 @@ on:
         options:
           - new-release
           - new-patch
+          - finalize-rc
           - update-upstream-versions
       version:
         description: |
           Downstream Release Version. Eg: "1.22", "1.23", "next"
         required: true
         type: string
+
 permissions:
   contents: write
   pull-requests: write
+
 jobs:
   run-release:
     runs-on: ubuntu-latest
     env:
       # NOTE: in case of update, the defaults here are also specified in the run-name
-      ACTION: ${{ github.event.inputs.action || 'update-upstream-versions' }}
-      VERSION: ${{ github.event.inputs.version || 'next' }}
+      ACTION: ${{ inputs.action || 'update-upstream-versions' }}
+      VERSION: ${{ inputs.version || 'next' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/release-new-patch.yaml
+++ b/.github/workflows/release-new-patch.yaml
@@ -1,0 +1,24 @@
+name: Release Action - New Patch
+run-name: New Patch for version ${{ github.event.inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: |
+          Downstream Release Version. Eg: "1.22", "1.23"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  new-patch:
+    uses: ./.github/workflows/release-manager.yaml
+    with:
+      action: new-patch
+      version: ${{ github.event.inputs.version }}
+    secrets:
+      OPENSHIFT_PIPELINES_ROBOT: ${{ secrets.OPENSHIFT_PIPELINES_ROBOT }}

--- a/.github/workflows/release-new-release.yaml
+++ b/.github/workflows/release-new-release.yaml
@@ -1,0 +1,24 @@
+name: Release Action - New Release
+run-name: New Release for version ${{ github.event.inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: |
+          Downstream Release Version. Eg: "1.22", "1.23"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  new-release:
+    uses: ./.github/workflows/release-manager.yaml
+    with:
+      action: new-release
+      version: ${{ github.event.inputs.version }}
+    secrets:
+      OPENSHIFT_PIPELINES_ROBOT: ${{ secrets.OPENSHIFT_PIPELINES_ROBOT }}

--- a/.github/workflows/release-update-upstream-versions.yaml
+++ b/.github/workflows/release-update-upstream-versions.yaml
@@ -1,0 +1,73 @@
+name: Release Action - Update Upstream Versions
+run-name: Update Upstream Versions for ${{ github.event.inputs.version || 'next and RC versions' }}
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # At every day at 00
+  workflow_dispatch:
+    inputs:
+      version:
+        description: |
+          Downstream Release Version. Eg: "1.22", "1.23", "next"
+        required: false
+        type: string
+        default: next
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  gather-versions-for-auto-upgrade:
+    runs-on: ubuntu-latest
+    outputs:
+      auto-upgrade-versions: ${{steps.gather-versions.outputs.auto-upgrade-versions}}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Generate upgrade matrix
+        id: gather-versions
+        run: |
+          #!/bin/bash
+          VERSION="${{ github.event.inputs.version }}"
+
+          # If workflow_dispatch, use the input version
+          if [[ -n "${VERSION}" ]]; then
+            echo "auto-upgrade-versions=[\"$VERSION\"]" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # If scheduled, gather versions from release files
+          VERSIONS=()
+
+          for file in config/downstream/releases/*.yaml; do
+            # Get patch-version from the file
+            PATCH_VERSION=$(yq eval '.patch-version' "$file")
+
+            # Check if patch-version is "next" or ends with -RC-\d+
+            if [[ "$PATCH_VERSION" == "next" ]] || [[ "$PATCH_VERSION" =~ -RC-[0-9]+$ ]]; then
+              # Get the version field, or derive from filename
+              VERSION=$(yq eval '.version' "$file")
+
+              if [[ "$VERSION" == "null" ]]; then
+                VERSION=$(basename --suffix .yaml "$file")
+              fi
+
+              VERSIONS+=("\"$VERSION\"")
+            fi
+          done
+
+          JSON_ARRAY=$(IFS=,; echo "[${VERSIONS[*]}]")
+          echo "auto-upgrade-versions=${JSON_ARRAY}" >> $GITHUB_OUTPUT
+
+
+  update-upstream-versions:
+    needs: gather-versions-for-auto-upgrade
+    strategy:
+      matrix:
+        version: ${{ fromJSON(needs.gather-versions-for-auto-upgrade.outputs.auto-upgrade-versions) }}
+    uses: ./.github/workflows/release-manager.yaml
+    with:
+      action: update-upstream-versions
+      version: ${{ matrix.version }}
+    secrets:
+      OPENSHIFT_PIPELINES_ROBOT: ${{ secrets.OPENSHIFT_PIPELINES_ROBOT }}

--- a/.github/workflows/release-update-upstream-versions.yaml
+++ b/.github/workflows/release-update-upstream-versions.yaml
@@ -40,11 +40,11 @@ jobs:
           VERSIONS=()
 
           for file in config/downstream/releases/*.yaml; do
-            # Get patch-version from the file
-            PATCH_VERSION=$(yq eval '.patch-version' "$file")
+            # Get release-tag from the file
+            RELEASE_TAG=$(yq eval '.release-tag' "$file")
 
-            # Check if patch-version is "next" or ends with -RC-\d+
-            if [[ "$PATCH_VERSION" == "next" ]] || [[ "$PATCH_VERSION" =~ -RC-[0-9]+$ ]]; then
+            # Check if release-tag is "next" or ends with -RC-\d+
+            if [[ "$RELEASE_TAG" == "next" ]] || [[ "$RELEASE_TAG" =~ -RC-[0-9]+$ ]]; then
               # Get the version field, or derive from filename
               VERSION=$(yq eval '.version' "$file")
 

--- a/README.md
+++ b/README.md
@@ -5,19 +5,27 @@ Contains a bunch of hack used for `openshift-pipelines` repositories.
 - Generate prow configuration (and sync in `openshift/release`)
   - For `task*` repositories.
 - Generate github workflows "matrix" for `task*` repositories.
+- Generate and store the configuration for Konflux resources and automation (build PipelineRuns, ReleasePlans, etc)
+
 ---
 ## Adding New Release
-Now release can be added just a click of button. 
-- From Action Menu on github select action "Automated Release Actions"
-- Run Workflow
-- Select appropriate Branch
-- Action : new-release
-- Version: Provide the version you want to add e.g 1.23
-- Run Workflow
-- This workflow will add new PR to hack repo with updated version configuration.
+Now release can be added just a click of button.
+- From Action Menu on github select action "Release Action - New Release"
+- Run Workflow with the following inputs:
+  - Select `main` branch
+  - Version: Provide the version you want to add e.g `1.23` (will create the tag `1.23.0-RC-1`)
+- This workflow will add new PR to hack repo with updated version configuration for the Release Candidate.
+- Verify the PR and merge
+- Repeat the above for subsequent Release Candidate builds
+- When ready to create the final pre-stage release, from the Action Menu on Github run select the action "Release Action - Finalize RC"
+- Run the workflow with the following inputs:
+  - Select `main` branch
+  - Version: Provide the version you want to finalize (e.g. `1.23`)
+- This workflow will add new PR to the hack repo that removes the RC suffix from the release's version.
 - Verify the PR and merge
 
-After PR is merged then new workflow will be triggered which will generate release configuration in all the Repos.
+After the initial PR is merged then new workflow will be triggered which will generate release configuration in all the Repos.
+The initial release will be configured as a Release Candidate with a version like 1.23.0-RC-1.
 
 ---
 ## Adding New Patch
@@ -55,7 +63,7 @@ versions for unreleased versions which you can do by this workflow.
 After PR is merged then new workflow will be triggered which will generate release configuration in all the Repos.
 
 ---
-
+ 
 
 TODO for automation:
 (waveywaves)

--- a/cmd/konflux/main.go
+++ b/cmd/konflux/main.go
@@ -68,7 +68,7 @@ func main() {
 		versionConfig.Version.ImagePrefix = config.ImagePrefix + versionConfig.Version.ImagePrefix
 		versionConfig.Version.Version = *version
 		if versionConfig.Version.Version == "next" || versionConfig.Version.Version == "nightly" {
-			versionConfig.Version.PatchVersion = *version
+			versionConfig.Version.ReleaseTag = *version
 		}
 	}
 

--- a/cmd/konflux/main.go
+++ b/cmd/konflux/main.go
@@ -68,9 +68,7 @@ func main() {
 		versionConfig.Version.ImagePrefix = config.ImagePrefix + versionConfig.Version.ImagePrefix
 		versionConfig.Version.Version = *version
 		if versionConfig.Version.Version == "next" || versionConfig.Version.Version == "nightly" {
-			versionConfig.Version.PatchVersion = versionConfig.Version.PatchVersion
-		} else if !strings.HasPrefix(versionConfig.Version.PatchVersion, "v") {
-			versionConfig.Version.PatchVersion = "v" + versionConfig.Version.PatchVersion
+			versionConfig.Version.PatchVersion = *version
 		}
 	}
 

--- a/component-monitor/generate_data.py
+++ b/component-monitor/generate_data.py
@@ -142,7 +142,7 @@ def load_release_configs():
         version = str(data.get("version", version_key))
         releases[version_key] = {
             "version": version,
-            "patch_version": str(data.get("patch-version", "")),
+            "release_tag": str(data.get("release-tag", "")),
             "code_freeze": data.get("code-freeze", False),
             "branches": data.get("branches", {}),
         }
@@ -883,7 +883,7 @@ def main():
 
         result["versions"][version_key] = {
             "version": version,
-            "patch_version": release["patch_version"],
+            "release_tag": release["release_tag"],
             "code_freeze": release["code_freeze"],
             "comp_yaml_url": comp_yaml_url,
             "components": components_data,

--- a/component-monitor/index.html
+++ b/component-monitor/index.html
@@ -778,7 +778,7 @@
       document.getElementById("components-label").style.display = "block";
       document.getElementById("version-info").innerHTML = `
         <div><span>Version:</span> <strong>${versionData.version}</strong></div>
-        <div><span>Patch:</span> <strong>${versionData.patch_version || "-"}</strong></div>
+        <div><span>Patch:</span> <strong>${versionData.release_tag || "-"}</strong></div>
         <div><span>Code Freeze:</span>
           <span class="code-freeze-badge ${versionData.code_freeze ? "active" : "inactive"}">
             ${versionData.code_freeze ? "Active" : "Inactive"}
@@ -877,7 +877,7 @@
         btn.appendChild(dot);
 
         const label = document.createElement("span");
-        const suffix = v.patch_version && v.patch_version !== v.version ? ` (${v.patch_version})` : "";
+        const suffix = v.release_tag&& v.release_tag!== v.version ? ` (${v.release_tag})` : "";
         label.textContent = v.version + suffix;
         btn.appendChild(label);
 

--- a/config/downstream/releases/1.15.yaml
+++ b/config/downstream/releases/1.15.yaml
@@ -1,6 +1,6 @@
 version: "1.15"
 image-suffix: -rhel8
-patch-version: 1.15.5
+release-tag: 1.15.5
 code-freeze: false
 docker-file-options:
   args:

--- a/config/downstream/releases/1.20.yaml
+++ b/config/downstream/releases/1.20.yaml
@@ -1,6 +1,6 @@
 version: "1.20"
 image-suffix: -rhel9
-patch-version: 1.20.5
+release-tag: 1.20.5
 code-freeze: true
 branches:
   git-init:

--- a/config/downstream/releases/1.21.yaml
+++ b/config/downstream/releases/1.21.yaml
@@ -1,5 +1,5 @@
 version: 1.21
-patch-version: 1.21.2
+release-tag: 1.21.2
 image-suffix: "-rhel9"
 code-freeze: false
 branches:

--- a/config/downstream/releases/1.22.yaml
+++ b/config/downstream/releases/1.22.yaml
@@ -1,5 +1,5 @@
 version: 1.22
-patch-version: 1.22.2
+release-tag: 1.22.2
 image-suffix: "-rhel9"
 code-freeze: false
 branches:

--- a/config/downstream/releases/1.23.yaml
+++ b/config/downstream/releases/1.23.yaml
@@ -1,5 +1,5 @@
 version: 1.23
-patch-version: 1.23.0
+release-tag: 1.23.0
 image-suffix: "-rhel9"
 code-freeze: false
 branches:

--- a/config/downstream/releases/next.yaml
+++ b/config/downstream/releases/next.yaml
@@ -33,4 +33,4 @@ branches:
     upstream: release-v0.1.x
   multicluster-proxy-aae:
     upstream: release-v0.1.x
-patch-version: next
+release-tag: next

--- a/config/downstream/releases/nightly.yaml
+++ b/config/downstream/releases/nightly.yaml
@@ -1,5 +1,5 @@
 version: nightly
-patch-version: latest
+release-tag: latest
 image-suffix: "-rhel10"
 code-freeze: false
 docker-file-options:

--- a/config/upstream/konflux.yaml
+++ b/config/upstream/konflux.yaml
@@ -3,5 +3,5 @@ applications:
   - multicluster-proxy-aae
 versions:
   - version: 0.1
-    patch-version: v0.1.1
+    release-tag: v0.1.1
     image-suffix: "-rhel9"

--- a/config/upstream/multicluster-proxy-aae.yaml
+++ b/config/upstream/multicluster-proxy-aae.yaml
@@ -2,5 +2,5 @@ applications:
   - multicluster-proxy-aae
 versions:
   - version: 0.1
-    patch-version: v0.1.1
+    release-tag: v0.1.1
     image-suffix: "-rhel9"

--- a/config/upstream/releases/0.1.yaml
+++ b/config/upstream/releases/0.1.yaml
@@ -1,3 +1,3 @@
 version: 0.1
-patch-version: v0.1.1
+release-tag: v0.1.1
 image-suffix: "-rhel9"

--- a/config/upstream/releases/0.2.yaml
+++ b/config/upstream/releases/0.2.yaml
@@ -1,3 +1,3 @@
 version: 0.2
-patch-version: 0.2.0
+release-tag: 0.2.0
 image-suffix: "-rhel9"

--- a/config/upstream/releases/0.3.yaml
+++ b/config/upstream/releases/0.3.yaml
@@ -1,2 +1,2 @@
 version: 0.3
-patch-version: v0.3.0
+release-tag: v0.3.0

--- a/config/upstream/syncer-service.yaml
+++ b/config/upstream/syncer-service.yaml
@@ -2,5 +2,5 @@ applications:
   - syncer-service
 versions:
   - version: 0.1
-    patch-version: v0.1.1
+    release-tag: v0.1.1
     image-suffix: "-rhel9"

--- a/config/upstream/tekton-kueue.yaml
+++ b/config/upstream/tekton-kueue.yaml
@@ -2,5 +2,5 @@ applications:
   - tekton-kueue
 versions:
   - version: 0.3
-    patch-version: v0.3.1
+    release-tag: v0.3.1
     image-suffix: "-rhel9"

--- a/hack/common-functions.sh
+++ b/hack/common-functions.sh
@@ -18,7 +18,7 @@ function finalize-rc-release() {
   RELEASE_VERSION=$1
   RELEASE_YAML="$ROOT/config/downstream/releases/${RELEASE_VERSION}.yaml"
 
-  patch_version=$(yq ".patch-version" "${RELEASE_YAML}")
+  release_tag=$(yq ".release-tag" "${RELEASE_YAML}")
 
   # Only "finalize" RC versions, which have a version like "1.2.3-RC-1"
   if [[ ! "${release_tag}" =~ [0-9]+\.[0-9]+\.[0-9]+-RC-[0-9]+ ]]; then
@@ -26,8 +26,8 @@ function finalize-rc-release() {
     return
   fi
 
-  next_version=$(echo "${patch_version}" | grep --only-matching  '^[0-9]\+\.[0-9]\+\.[0-9]\+')
-  yq -i e ".patch-version = \"${next_version}\"" "${RELEASE_YAML}"
+  next_version=$(echo "${release_tag}" | grep --only-matching  '^[0-9]\+\.[0-9]\+\.[0-9]\+')
+  yq -i e ".release-tag = \"${next_version}\"" "${RELEASE_YAML}"
 
   echo "Finalized RC release: ${next_version}"
 }
@@ -61,21 +61,21 @@ function create-new-patch() {
   unfreeze-if-needed "$RELEASE_YAML"
 
   if [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
-    patch_version=$(yq ".patch-version" "${RELEASE_YAML}")
-    echo "Current Patch Version $patch_version"
-    if [[ -z "$patch_version" || "$patch_version" == "null" ]]; then
+    release_tag=$(yq ".release-tag" "${RELEASE_YAML}")
+    echo "Current tag $release_tag"
+    if [[ -z "$release_tag" || "$release_tag" == "null" ]]; then
       # Always initialize a new version as x.y.0-RC-1
       next_version="${RELEASE_VERSION}.0-RC-1"
     else
-      last_num=$(echo "${patch_version}" | grep --only-matching "[0-9]\+$")
-      base_version=$(echo "${patch_version}" | grep -v --only-matching "[0-9]\+$")
+      last_num=$(echo "${release_tag}" | grep --only-matching "[0-9]\+$")
+      base_version=$(echo "${release_tag}" | grep -v --only-matching "[0-9]\+$")
       next_version="${base_version}$((last_num + 1))"
     fi
   else
       next_version="$RELEASE_VERSION"
   fi
-  echo "next patch Version: $next_version"
-  yq -i e ".patch-version = \"$next_version\"" "${RELEASE_YAML}"
+  echo "next tag: $next_version"
+  yq -i e ".release-tag = \"$next_version\"" "${RELEASE_YAML}"
 }
 
 function update-upstream-versions() {

--- a/hack/common-functions.sh
+++ b/hack/common-functions.sh
@@ -14,10 +14,28 @@ function unfreeze-if-needed() {
   fi
 }
 
+function finalize-rc-release() {
+  RELEASE_VERSION=$1
+  RELEASE_YAML="$ROOT/config/downstream/releases/${RELEASE_VERSION}.yaml"
+
+  patch_version=$(yq ".patch-version" "${RELEASE_YAML}")
+
+  # Only "finalize" RC versions, which have a version like "1.2.3-RC-1"
+  if [[ ! "${release_tag}" =~ [0-9]+\.[0-9]+\.[0-9]+-RC-[0-9]+ ]]; then
+    echo "Version $release_tag is not an RC version. Nothing to finalize."
+    return
+  fi
+
+  next_version=$(echo "${patch_version}" | grep --only-matching  '^[0-9]\+\.[0-9]\+\.[0-9]\+')
+  yq -i e ".patch-version = \"${next_version}\"" "${RELEASE_YAML}"
+
+  echo "Finalized RC release: ${next_version}"
+}
+
 function create-new-release() {
   RELEASE_VERSION=$1
   RELEASE_YAML="$ROOT/config/downstream/releases/${RELEASE_VERSION}.yaml"
-  touch $RELEASE_YAML
+  touch "${RELEASE_YAML}"
 
 
   # If version already exists then no action required
@@ -28,37 +46,39 @@ function create-new-release() {
   fi
 
   # Add New version in konflux.yaml
-#  yq -i e ".versions += \"$RELEASE_VERSION\"" $KONFLUX_YAML
+  #  yq -i e ".versions += \"$RELEASE_VERSION\"" $KONFLUX_YAML
 
   #Add Release name in $RELEASE_YAML
-  yq -i e ".version = \"$RELEASE_VERSION\"" $RELEASE_YAML
-  yq -i e ".image-suffix = \"-rhel9\"" $RELEASE_YAML
-  create-new-patch $RELEASE_VERSION
-  update-upstream-versions $RELEASE_VERSION
+  yq -i e ".version = \"$RELEASE_VERSION\"" "${RELEASE_YAML}"
+  yq -i e ".image-suffix = \"-rhel9\"" "${RELEASE_YAML}"
+  create-new-patch "${RELEASE_VERSION}"
+  update-upstream-versions "${RELEASE_VERSION}"
 }
 
-
-function create-new-patch(){
+function create-new-patch() {
   RELEASE_VERSION=$1
   RELEASE_YAML="$ROOT/config/downstream/releases/${RELEASE_VERSION}.yaml"
   unfreeze-if-needed "$RELEASE_YAML"
 
   if [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
-    patch_version=$(yq ".patch-version" $RELEASE_YAML)
+    patch_version=$(yq ".patch-version" "${RELEASE_YAML}")
     echo "Current Patch Version $patch_version"
     if [[ -z "$patch_version" || "$patch_version" == "null" ]]; then
-      next_version="${RELEASE_VERSION}.0"
+      # Always initialize a new version as x.y.0-RC-1
+      next_version="${RELEASE_VERSION}.0-RC-1"
     else
-      next_version=$(echo "$patch_version" | awk -F. '{printf "%d.%d.%d\n", $1, $2, $3+1}')
+      last_num=$(echo "${patch_version}" | grep --only-matching "[0-9]\+$")
+      base_version=$(echo "${patch_version}" | grep -v --only-matching "[0-9]\+$")
+      next_version="${base_version}$((last_num + 1))"
     fi
   else
       next_version="$RELEASE_VERSION"
   fi
   echo "next patch Version: $next_version"
-  yq -i e ".patch-version = \"$next_version\"" $RELEASE_YAML
+  yq -i e ".patch-version = \"$next_version\"" "${RELEASE_YAML}"
 }
 
-update-upstream-versions() {
+function update-upstream-versions() {
   RELEASE_VERSION=$1
   RELEASE_YAML="$ROOT/config/downstream/releases/${RELEASE_VERSION}.yaml"
   touch $RELEASE_YAML
@@ -66,13 +86,11 @@ update-upstream-versions() {
   echo "Updating upstream version for release : $RELEASE_VERSION in $RELEASE_YAML"
 
   for file in "$REPO_DIR"/*.yaml; do
-    [ -e "$file" ] || continue  # Skip if no files
+    [ -e "$file" ] || continue # Skip if no files
 
-    # Extract values with yq
     downstream="$(basename "$file" .yaml)"
     upstream=$(yq e '.upstream' "$file")
     UsePatchBranch=$(yq e '.use-patch-branch' "$file")
-    # Skip when upstream is empty
     [ "$upstream" = "null" ] && upstream=""
     if [[ -z "$upstream" || "$upstream" == "tektoncd/operator" ]]; then
       continue
@@ -94,7 +112,5 @@ update-upstream-versions() {
     yq -i e ".branches.$downstream.upstream = \"$BRANCH\"" $RELEASE_YAML
   done
 }
-
-
 
 

--- a/hack/release-manager.sh
+++ b/hack/release-manager.sh
@@ -8,7 +8,6 @@ ROOT="$(dirname "$SCRIPT_DIR")"
 
 source $SCRIPT_DIR/common-functions.sh
 
-# Default values
 DEFAULT_ACTION="update-upstream-versions"
 DEFAULT_VERSION="next"
 ACTION=""
@@ -21,8 +20,9 @@ Usage: $0 [OPTIONS]
 
 Required Flags:
   --action, -a        Action to perform. Supported values:
-                        * new-release              Create a new release version
-                        * new-patch                Create a new patch version
+                        * new-release              Create a new release candidate
+                        * new-patch                Create or increment a patch version
+                        * finalize-rc              Finalize a release candidate by dropping -RC suffix
                         * update-upstream-versions Update upstream related versions
 
   --version, -v       Version to operate on (e.g., 1.23.0)
@@ -33,7 +33,9 @@ Optional Flags:
 
 Examples:
   $0 --action new-release --version 1.23.0
+  $0 -a new-release -v 1.24
   $0 -a new-patch -v 1.23.0
+  $0 -a finalize-rc -v 1.24
   $0 -a update-upstream-versions -v 1.24.0
 
 Description:
@@ -41,12 +43,22 @@ Description:
   internal functions based on the selected action:
     - create-new-release
     - create-new-patch
+    - finalize-rc-release
     - update-upstream-versions
+
+RC Workflow:
+  1. Use 'new-release' to create initial x.y.0-RC-1 release
+  2. Continue using 'new-release' to increment RC number
+  3. Use 'finalize-rc' to manually drop RC suffix when ready
+
+Note:
+  During RC mode (before x.y.0), upstream component versions are automatically
+  updated when higher versions are released upstream. After x.y.0 release,
+  minor versions of upstream components do not auto-update.
 EOF
   exit 1
 }
 
-# Parse named args
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --action | -a)
@@ -67,7 +79,6 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Use Default Values for required params
 if [[ -z "$ACTION"  ]]; then
   echo "Using default action $DEFAULT_ACTION!"
   ACTION=$DEFAULT_ACTION
@@ -77,16 +88,18 @@ if [[ -z "$VERSION"  ]]; then
   VERSION=$DEFAULT_VERSION
 fi
 
-# Call specific function based on ACTION
 case "$ACTION" in
   "new-release")
-    create-new-release $VERSION
+    create-new-release "${VERSION}"
     ;;
   "new-patch")
-    create-new-patch $VERSION
+    create-new-patch "${VERSION}"
+    ;;
+  "finalize-rc")
+    finalize-rc-release "${VERSION}"
     ;;
   "update-upstream-versions")
-    update-upstream-versions $VERSION
+    update-upstream-versions "${VERSION}"
     ;;
   *)
     echo "Invalid action: $ACTION"

--- a/internal/konflux/config.go
+++ b/internal/konflux/config.go
@@ -1,5 +1,10 @@
 package konflux
 
+import (
+	"fmt"
+	"strings"
+)
+
 type Config struct {
 	Organization   string `yaml:"organization"`
 	Namespace      string `yaml:"namespace"`
@@ -89,7 +94,27 @@ type Release struct {
 	ImagePrefix       string            `json:"image-prefix" yaml:"image-prefix"`
 	ImageSuffix       string            `json:"image-suffix" yaml:"image-suffix"`
 	CodeFreeze        bool              `json:"code-freeze" yaml:"code-freeze"`
+	IsRC              bool              `json:"is-rc" yaml:"is-rc"`
+	RCNumber          int               `json:"rc-number" yaml:"rc-number"`
 	DockerFileOptions DockerFileOptions `json:"docker-file-options" yaml:"docker-file-options"`
+}
+
+func (r Release) FullVersion() string {
+	if r.Version == "main" || r.Version == "next" {
+		return r.Version
+	}
+
+	version := r.PatchVersion
+
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+
+	if r.IsRC {
+		version += fmt.Sprintf("-RC-%d", r.RCNumber)
+	}
+
+	return version
 }
 
 type ApplicationConfig struct {

--- a/internal/konflux/config.go
+++ b/internal/konflux/config.go
@@ -1,7 +1,7 @@
 package konflux
 
 import (
-	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -88,30 +88,27 @@ type Patch struct {
 	Name   string
 	Script string
 }
+
+var NON_RELEASE_VERSIONS = []string{"main", "next", "nightly"}
+
 type Release struct {
 	Version           string
-	PatchVersion      string            `json:"patch-version" yaml:"patch-version"`
+	ReleaseTag        string            `json:"release-tag" yaml:"release-tag" comment:"Not used for versions like nightly, next, etc"`
 	ImagePrefix       string            `json:"image-prefix" yaml:"image-prefix"`
 	ImageSuffix       string            `json:"image-suffix" yaml:"image-suffix"`
 	CodeFreeze        bool              `json:"code-freeze" yaml:"code-freeze"`
-	IsRC              bool              `json:"is-rc" yaml:"is-rc"`
-	RCNumber          int               `json:"rc-number" yaml:"rc-number"`
 	DockerFileOptions DockerFileOptions `json:"docker-file-options" yaml:"docker-file-options"`
 }
 
 func (r Release) FullVersion() string {
-	if r.Version == "main" || r.Version == "next" {
+	if slices.Contains(NON_RELEASE_VERSIONS, r.Version) {
 		return r.Version
 	}
 
-	version := r.PatchVersion
+	version := r.ReleaseTag
 
 	if !strings.HasPrefix(version, "v") {
 		version = "v" + version
-	}
-
-	if r.IsRC {
-		version += fmt.Sprintf("-RC-%d", r.RCNumber)
 	}
 
 	return version

--- a/internal/konflux/dockerfile_utils.go
+++ b/internal/konflux/dockerfile_utils.go
@@ -187,7 +187,7 @@ func getDockerFileLabels(component Component) map[string]string {
 	labels := map[string]string{
 		"com.redhat.component": fmt.Sprintf("openshift-%s-container", component.Image),
 		"name":                 fmt.Sprintf("openshift-pipelines/%s", component.Image),
-		"version":              component.Version.PatchVersion,
+		"version":              component.Version.FullVersion(),
 		"maintainer":           "pipelines-extcomm@redhat.com",
 		"summary":              fmt.Sprintf("Red Hat OpenShift Pipelines %s %s", component.Repository.Name, component.Name),
 		"description":          fmt.Sprintf("Red Hat OpenShift Pipelines %s %s", component.Repository.Name, component.Name),

--- a/internal/konflux/templates/konflux/release-plan-admission.yaml
+++ b/internal/konflux/templates/konflux/release-plan-admission.yaml
@@ -45,7 +45,7 @@ spec:
         tags:
           - "{{ "{{ git_sha }}" }}"
           - "{{ "{{ git_short_sha }}" }}"
-          - "{{.Release.Version  }}{{ "-{{ timestamp }}" }}"
+          - "{{.Release.FullVersion  }}{{ "-{{ timestamp }}" }}"
         pushSourceContainer: true
     intention: {{ $intention }}
     enforceContainerFirstSecurityLabels: true

--- a/internal/konflux/templates/konflux/release-plan-managed.yaml
+++ b/internal/konflux/templates/konflux/release-plan-managed.yaml
@@ -13,8 +13,8 @@ spec:
     mapping:
       defaults:
         tags:
-          - {{ .Release.PatchVersion }}
-          - {{ .Release.PatchVersion }}-{{"{{ timestamp }}"}}
+          - {{ .Release.FullVersion }}
+          - {{ .Release.FullVersion }}-{{"{{ timestamp }}"}}
     releaseNotes:
       references:
         - "https://docs.redhat.com/en/documentation/red_hat_openshift_pipelines"
@@ -26,11 +26,11 @@ spec:
         platforms by abstracting away the underlying implementation details.
         Tekton introduces a number of standard custom resource definitions (CRDs)
         for defining CI/CD pipelines that are portable across Kubernetes distributions.
-      description: "The {{ .Release.PatchVersion | trimPrefix "v" }} release of Red Hat OpenShift Pipelines Operator."
+      description: "The {{ .Release.FullVersion | trimPrefix "v" }} release of Red Hat OpenShift Pipelines Operator."
       topic: |
-        The {{ .Release.PatchVersion | trimPrefix "v" }} GA release of Red Hat OpenShift Pipelines Operator..
+        The {{ .Release.FullVersion | trimPrefix "v" }} GA release of Red Hat OpenShift Pipelines Operator..
         For more details see [product documentation](https://docs.redhat.com/en/documentation/red_hat_openshift_pipelines).
-      synopsis: "Red Hat OpenShift Pipelines Release {{ .Release.PatchVersion | trimPrefix "v" }}"
+      synopsis: "Red Hat OpenShift Pipelines Release {{ .Release.FullVersion | trimPrefix "v" }}"
   collectors:
     serviceAccountName: tekton-ecosystem-collectors-sa
     secrets:
@@ -41,7 +41,7 @@ spec:
           - name: url
             value: https://issues.redhat.com
           - name: query
-            value: 'project = SRVKP AND fixVersion = "Pipelines {{ .Release.PatchVersion | trimPrefix "v" }}" AND component NOT IN (QA, Performance, p12n, Operator, "Tekton CLI", "OpenShift OPC") AND (status = "Release Pending" OR (status = Closed AND resolution = Done)) AND (labels is EMPTY OR labels != "release-testing-bug") AND (issuetype = Epic OR ((issuetype IN (Story, Bug)) AND "Epic Link" is EMPTY))'
+            value: 'project = SRVKP AND fixVersion = "Pipelines {{ .Release.FullVersion | trimPrefix "v" }}" AND component NOT IN (QA, Performance, p12n, Operator, "Tekton CLI", "OpenShift OPC") AND (status = "Release Pending" OR (status = Closed AND resolution = Done)) AND (labels is EMPTY OR labels != "release-testing-bug") AND (issuetype = Epic OR ((issuetype IN (Story, Bug)) AND "Epic Link" is EMPTY))'
           - name: secretName
             value: jira-collectors-secret
         timeout: 120

--- a/internal/konflux/templates/konflux/release-plan.yaml
+++ b/internal/konflux/templates/konflux/release-plan.yaml
@@ -22,6 +22,6 @@ spec:
           value: pipelines/release-pipeline.yaml
     params:
       - name: release_version
-        value: "{{.Release.PatchVersion}}"
+        value: "{{.Release.FullVersion}}"
       - name: release_to_github
         value: "{{.ReleaseToGitHub}}"

--- a/internal/konflux/templates/konflux/release-plan.yaml
+++ b/internal/konflux/templates/konflux/release-plan.yaml
@@ -22,6 +22,6 @@ spec:
           value: pipelines/release-pipeline.yaml
     params:
       - name: release_version
-        value: "{{.Release.FullVersion}}"
+        value: "{{.Release.ReleaseTag}}"
       - name: release_to_github
         value: "{{.ReleaseToGitHub}}"

--- a/internal/konflux/templates/tekton/component-pull-request.yaml
+++ b/internal/konflux/templates/tekton/component-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
     value: {{.Dockerfile}}
   - name: additional-tags
     value:
-      - "on-pr-{{- .Application.Release.PatchVersion}}"
+      - "on-pr-{{- .Application.Release.FullVersion}}"
   - name: build-platforms
     value:
     - linux/x86_64

--- a/internal/konflux/templates/tekton/component-push.yaml
+++ b/internal/konflux/templates/tekton/component-push.yaml
@@ -43,7 +43,7 @@ spec:
     value: {{.Dockerfile}}
   - name: additional-tags
     value:
-      - "{{- .Application.Release.PatchVersion}}"
+      - "{{- .Application.Release.ReleaseTag}}"
   {{- if contains "bundle" .Name  }}
   - name: build-platforms
     value:


### PR DESCRIPTION
# Overview
Add support for Release Candidate (RC) builds.
- Add a new subcommand to release manager, `finalize-rc`, which converts an RC build to a regular release build
- Modify the `new-release` command to create new versions in RC mode (with `-RC-1` trailer). Subsequent `new-release` calls to the same version increment the RC number.
- Extend the Automated Release Actions Github Workflow to support Finalizing Release Candidate Releases.
- Add a dedicated Github Workflow for each Release Action, though each in turn simply calls the shared "Automated Release Actions" workflow with the corresponding parameters.

# Schema Changes
Release files' `patch-version` field has been renamed `release-tag`

# Workflow overview
When a release captain is preparing for a new release, they now do the following:
1. Create an RC build using the Github Workflow `Release Action - New Release`, which generates a Release File with `<version>-RC-1`.
2. Make any necessary changes to the versions included in the Release File
3. Run the `Generate konflux configurations` Github Workflow (or ensure it was run automatically), which generates the Konflux configuration files (release plan, application, etc) with `version: x.y` but the Release Plan's `release_version` set to `vX.Y.Z-RC-1`.
4. Ensure the various components' pull requests are all merged, Konflux resources are applied, etc. proceed as normal
5. The automatic release process will release the operator index to development (push to quay.io) and tag the image with `vX.Y.Z-RC-N` (e.g. `v1.2.3-RC-1`). The Release Captain can give this image+tag to QA.
6. When the next release candidate is needed, the Release Captain can follow the process again (minus the component-PRs) to get the next RC build (RC-2)
7. Once the release is ready for the non-RC build, the Release Captain runs the Github Workflow `Release Action - Finalize RC` to update the Release File with `is-rc: false` and drop the `rc-version`.
8. They then ensure the Konflux resources are all updated and applied on the cluster
9. The next release will use the `release_version` as normal, no `-RC-n` suffix.