### PR TITLE
Add Slack notification for Konflux build failures

### DIFF
--- a/cmd/konflux/main.go
+++ b/cmd/konflux/main.go
@@ -282,13 +282,10 @@ func readApplications(dir, applicationName string, versionConfig k.ReleaseConfig
 			Config:          config,
 		}
 		for _, repoName := range applicationConfig.Repositories {
-			repo, err := readRepository(dir, repoName, &application, versionConfig.Branches[repoName])
+			repo, err := readRepository(dir, repoName, &application, versionConfig.Branches[repoName], config.Owners[repoName])
 
 			if err != nil {
 				return []k.Application{}, err
-			}
-			if o, ok := config.Owners[repoName]; ok {
-				repo.Owners = o
 			}
 			application.Components = append(application.Components, repo.Components...)
 			application.Repositories = append(application.Repositories, repo)
@@ -348,13 +345,14 @@ func updateRepository(name string, repo *k.Repository, a k.Application) error {
 }
 
 // readRepository reads a repository resource from the repos directory
-func readRepository(dir, repoName string, app *k.Application, branch k.Branch) (k.Repository, error) {
+func readRepository(dir, repoName string, app *k.Application, branch k.Branch, owners []string) (k.Repository, error) {
 	repository, err := readResource[k.Repository](dir, "repos", repoName)
 	if err != nil {
 		return k.Repository{}, err
 	}
 
 	repository.Branch = branch
+	repository.Owners = owners
 	if err := updateRepository(repoName, &repository, *app); err != nil {
 		return k.Repository{}, err
 	}

--- a/config/downstream/owners.yaml
+++ b/config/downstream/owners.yaml
@@ -1,48 +1,52 @@
-# Slack owners for repos (cc'd on workflow failure notifications).
-# Supports individual users and user groups.
+# Slack owners for repos (tagged on pipeline/workflow failure notifications).
+# Supports subteams (groups) and individual members.
 # Format:
 #   repo-name:
-#     - "<@SLACK_MEMBER_ID>"            # individual user (Profile > "..." > Copy member ID)
-#     - "<!subteam^SLACK_GROUP_ID>"     # user group (e.g. @team-name)
+#     - "SLACK_SUBTEAM_ID"   # subteam / user group (e.g. S050DUBQXST)
+#     - "SLACK_MEMBER_ID"    # individual user  (e.g. U024BE7LH)
+# Find subteam IDs: Slack > team profile > copy ID (starts with S)
+# Find member IDs:  Slack > user profile > "..." > Copy member ID (starts with U)
+
+# release
+release-captain:
+  - "S04NUBJ20RG"    # subteam
 
 # core
 git-init:
-  - "<!subteam^S04UX12MX8B>"
+  - "S04UX12MX8B"    # subteam
 manual-approval-gate:
-  - "<!subteam^S0B3NG4RH2Q>"
+  - "S0B3NG4RH2Q"    # subteam
 pipelines-as-code:
-  - "<!subteam^S04FWV1N021>"
+  - "S04FWV1N021"    # subteam
 tekton-caches:
-  - "<!subteam^S0B3JT5KR34>"
+  - "S0B3JT5KR34"    # subteam
 tekton-kueue:
-  - "<!subteam^S0AS9T1JWHM>"
+  - "S0AS9T1JWHM"    # subteam
 tektoncd-chains:
-  - "<!subteam^S050DUERQ4X>"
+  - "S050DUERQ4X"    # subteam
 tektoncd-hub:
-  - "<!subteam^S050UAR1K8B>"
+  - "S050UAR1K8B"    # subteam
 tektoncd-pipeline:
-  - "<!subteam^S050DU2F7FH>"
+  - "S050DU2F7FH"    # subteam
 tektoncd-pruner:
-  - "<!subteam^S0B4D5U154G>"
+  - "S0B4D5U154G"    # subteam
 tektoncd-results:
-  - "<!subteam^S053P13TLDP>"
+  - "S053P13TLDP"    # subteam
 tektoncd-triggers:
-  - "<!subteam^S051731DAM7>"
+  - "S051731DAM7"    # subteam
 syncer-service:
-  - "<!subteam^S0AS9T1JWHM>"
+  - "S0AS9T1JWHM"    # subteam
 multicluster-proxy-aae:
-  - "<!subteam^S0AS9T1JWHM>"
+  - "S0AS9T1JWHM"    # subteam
 console-plugin-pf5:
-  - "<!subteam^S075RLXAELT>"
+  - "S075RLXAELT"    # subteam
 console-plugin:
-  - "<!subteam^S075RLXAELT>"
+  - "S075RLXAELT"    # subteam
 tektoncd-cli:
-  - "<!subteam^S050DUBQXST>"
+  - "S050DUBQXST"    # subteam
 opc:
-  - "<!subteam^S050DUBQXST>"
+  - "S050DUBQXST"    # subteam
 serve-tkn-cli:
-  - "<!subteam^S050DUBQXST>"
+  - "S050DUBQXST"    # subteam
 operator:
-  - "<!subteam^S050WTYHHGU>"
-
-
+  - "S050WTYHHGU"    # subteam

--- a/internal/konflux/templates/github/workflows/slack-notify-on-failure.yaml
+++ b/internal/konflux/templates/github/workflows/slack-notify-on-failure.yaml
@@ -44,10 +44,6 @@ jobs:
                     {
                       "type": "mrkdwn",
                       "text": "*Branch:*\n{{ "${{ github.event.workflow_run.head_branch }}" }}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Triggered by:*\n{{ "${{ github.event.workflow_run.actor.login }}" }}"
                     }
                   ]
                 },
@@ -55,7 +51,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "{{- range .Owners }} {{ . }}{{ end }} please investigate and fix this failure.\nReach out to the release captain if you need assistance."
+                    "text": "{{- range .Owners }} <!subteam^{{ . }}>{{ end }} please investigate and fix this failure.\nReach out to the release captain if you need assistance."
                   }
                 },
                 {

--- a/internal/konflux/templates/tekton/component-push.yaml
+++ b/internal/konflux/templates/tekton/component-push.yaml
@@ -56,6 +56,15 @@ spec:
     value: |
       {{ .PrefetchInput }}
   {{- end }}
+  - name: repo-name
+    value: "{{basename .Repository.Name}}"
+  {{- if .Repository.Owners }}
+  - name: slack-group-ids
+    value:
+    {{- range .Repository.Owners }}
+      - "{{ . }}"
+    {{- end }}
+  {{- end }}
   pipelineRef:
     name: {{- if  not (contains "index" .Name ) }} docker-build-ta {{- else}} fbc-build {{- end }}
   taskRunTemplate:

--- a/pipelines/release-pipeline.yaml
+++ b/pipelines/release-pipeline.yaml
@@ -164,3 +164,33 @@ spec:
                 name=${f#"$UPLOAD_DIR"/}
                 gh release upload "$TAG" "$f#$name" --clobber
               done
+  finally:
+    - name: notify-slack-on-failure
+      when:
+        - input: $(tasks.status)
+          operator: in
+          values: ["Failed"]
+      taskRef:
+        params:
+          - name: name
+            value: slack-webhook-notification
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:14766aebbf6f4739e1b7dde0406dcba2d1e300170d3b084f23df9fb074d87dc3
+          - name: kind
+            value: task
+        resolver: bundles
+      params:
+        - name: message
+          value: |
+            :red_circle: *Release Pipeline Failure*
+            *Snapshot:* $(params.snapshot)
+            *Version:* $(params.release_version)
+            *Logs:* https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/tekton-ecosystem-tenant/pipelinerun/$(context.pipelineRun.name)
+            Please investigate and fix this failure.
+        - name: secret-name
+          value: slack-webhook-secret
+        - name: key-name
+          value: webhook-url
+        - name: group-ids
+          value:
+            - "S04NUBJ20RG"


### PR DESCRIPTION
Use the slack-webhook-notification task from build-definitions
as a finally task in the release pipeline. Convert owners.yaml
to raw Slack team IDs and pass them as slack-group-ids through
generated PipelineRun specs. Remove the check_suite-based
slack-notify-on-build-failure GitHub Actions workflow since
pipeline-level notifications replace it.
Also remove the "Triggered by" field from the existing workflow failure notification template.


Assisted-by: Claude Opus 4 (via Claude Code)