### PR TITLE
Update pipelines-as-code upstream version to v0.47.x

### DIFF
--- a/config/downstream/releases/next.yaml
+++ b/config/downstream/releases/next.yaml
@@ -6,7 +6,7 @@ branches:
   opc:
     upstream: release-v1.22.x
   pipelines-as-code:
-    upstream: release-v0.46.x
+    upstream: release-v0.47.x
   tekton-assist:
     upstream: release-v0.1.x
   tekton-caches:


### PR DESCRIPTION
Bump PaC upstream pin from release-v0.46.x to release-v0.47.x for the next nightly build. PaC v0.47.0 includes CEL string/list extension functions, GitHub API rate limit events, and several bug fixes.