### PR TITLE
update setup-go action to v6

### DIFF
--- a/.github/workflows/component-monitor.yaml
+++ b/.github/workflows/component-monitor.yaml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Set up Go
         if: inputs.enable_konflux != 'false'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.23'
 

--- a/.github/workflows/generate-konflux.yaml
+++ b/.github/workflows/generate-konflux.yaml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.25.x
       - name: login

--- a/.github/workflows/validate-release-configs.yaml
+++ b/.github/workflows/validate-release-configs.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.25.x
       - name: Validate changed release configs against operator components.yaml


### PR DESCRIPTION
This resolves a warning all of our actions are emitting right now: 
<img width="1179" height="288" alt="image" src="https://github.com/user-attachments/assets/f78ca0ea-55b5-4b82-80e2-7e96f8117255" />
