### PR TITLE
feat: Generate CDN RPA and product config from hack.

### DIFF
--- a/internal/konflux/config_generator.go
+++ b/internal/konflux/config_generator.go
@@ -182,7 +182,7 @@ func generateKonfluxApplication(application Application, targetDir string) error
 		}
 
 		if application.ShortName == "core" {
-			if err := generateFileFromTemplate("product-cdn.yaml", application, filepath.Join(cdnProductDir, fmt.Sprintf("%s.yaml", strings.TrimPrefix(application.Release.PatchVersion, "v"))), application); err != nil {
+			if err := generateFileFromTemplate("product-cdn.yaml", application, filepath.Join(cdnProductDir, fmt.Sprintf("%s.yaml", strings.TrimPrefix(application.Release.FullVersion(), "v"))), application); err != nil {
 				return err
 			}
 		}

--- a/internal/konflux/templates/konflux/product-cdn.yaml
+++ b/internal/konflux/templates/konflux/product-cdn.yaml
@@ -1,6 +1,6 @@
 ---
-versionName: "{{ .Release.PatchVersion | trimPrefix "v" }}"
-ga: {{ hasSuffix .Release.PatchVersion "0" }}
+versionName: "{{ .Release.FullVersion | trimPrefix "v" }}"
+ga: {{ hasSuffix .Release.FullVersion "0" }}
 termsAndConditions: "Anonymous Download" # "Basic"
 hidden: false
 invisible: false

--- a/internal/konflux/templates/konflux/release-plan-admission-cdn.yaml
+++ b/internal/konflux/templates/konflux/release-plan-admission-cdn.yaml
@@ -71,7 +71,7 @@ spec:
           contentGateway:
             productName: "Cloud: OpenShift Pipelines"
             productCode: "pipelines"
-            productVersionName: "{{ .Release.PatchVersion | trimPrefix "v" }}"
+            productVersionName: "{{ .Release.FullVersion | trimPrefix "v" }}"
             mirrorOpenshiftPush: {{ $mirrorOpenshiftPush }}
             contentType: "binary"
       defaults:

--- a/internal/konflux/templates/konflux/release-plan.yaml
+++ b/internal/konflux/templates/konflux/release-plan.yaml
@@ -22,6 +22,6 @@ spec:
           value: pipelines/release-pipeline.yaml
     params:
       - name: release_version
-        value: "{{.Release.ReleaseTag}}"
+        value: "{{.Release.FullVersion}}"
       - name: release_to_github
         value: "{{.ReleaseToGitHub}}"


### PR DESCRIPTION
Component  config should not be generated for the releases where it not applicable