### PR TITLE
Update pipelines-as-code upstream version to v0.48.x

### DIFF
--- a/config/downstream/releases/next.yaml
+++ b/config/downstream/releases/next.yaml
@@ -6,7 +6,7 @@ branches:
   opc:
     upstream: release-v1.22.x
   pipelines-as-code:
-    upstream: release-v0.47.x
+    upstream: release-v0.48.x
   tekton-assist:
     upstream: release-v0.1.x
   tekton-caches:


### PR DESCRIPTION
Update pipelines-as-code upstream pin to release-v0.48.x (security release)