### PR TITLE
feat: command line option to  skip tekton file generattion

### DIFF
--- a/cmd/konflux/main.go
+++ b/cmd/konflux/main.go
@@ -30,7 +30,7 @@ func main() {
 	var version = flag.String("version", "next", "Release version to generate config")
 	var dryRun = flag.Bool("dry-run", false, "do not commit or push any changes")
 	var validate = flag.Bool("validate", false, "validate release config component versions against tektoncd/operator and exit")
-	var generateTekton = flag.Bool("generate-tekton", true, "validate release config component versions against tektoncd/operator and exit")
+	var generateTekton = flag.Bool("generate-tekton", true, "generate repository (Tekton/GitHub) config changes; set to false to only generate Konflux config")
 	flag.Parse()
 	configDir := filepath.Dir(*configFile)
 

--- a/cmd/konflux/main.go
+++ b/cmd/konflux/main.go
@@ -30,6 +30,7 @@ func main() {
 	var version = flag.String("version", "next", "Release version to generate config")
 	var dryRun = flag.Bool("dry-run", false, "do not commit or push any changes")
 	var validate = flag.Bool("validate", false, "validate release config component versions against tektoncd/operator and exit")
+	var generateTekton = flag.Bool("generate-tekton", true, "validate release config component versions against tektoncd/operator and exit")
 	flag.Parse()
 	configDir := filepath.Dir(*configFile)
 
@@ -68,9 +69,6 @@ func main() {
 		}
 		versionConfig.Version.ImagePrefix = config.ImagePrefix + versionConfig.Version.ImagePrefix
 		versionConfig.Version.Version = *version
-		if versionConfig.Version.Version == "next" || versionConfig.Version.Version == "nightly" {
-			versionConfig.Version.ReleaseTag = *version
-		}
 	}
 
 	for _, applicationName := range config.Applications {
@@ -81,7 +79,7 @@ func main() {
 		}
 		for _, application := range applications {
 			log.Printf("Loaded application: %s", application.Name)
-			if err := k.GenerateConfig(application, *dryRun); err != nil {
+			if err := k.GenerateConfig(application, *dryRun, *generateTekton); err != nil {
 				log.Fatal(err)
 			}
 		}
@@ -289,12 +287,15 @@ func readApplications(dir, applicationName string, versionConfig k.ReleaseConfig
 				return []k.Application{}, err
 			}
 			log.Printf("Reading repository Version: %v-%v-%s", repo.MinVersion, application.Release.Version, repo.Name)
-			if repo.MinVersion != "" && semver.Compare("v"+application.Release.Version, "v"+repo.MinVersion) < 0 {
+			_, err = strconv.ParseFloat(application.Release.Version, 64)
+
+			if err == nil && repo.MinVersion != "" && semver.Compare("v"+application.Release.Version, "v"+repo.MinVersion) < 0 {
 				continue
 			}
-			if repo.MaxVersion != "" && semver.Compare("v"+application.Release.Version, "v"+repo.MaxVersion) > 0 {
+			if err == nil && repo.MaxVersion != "" && semver.Compare("v"+application.Release.Version, "v"+repo.MaxVersion) > 0 {
 				continue
 			}
+
 			application.Components = append(application.Components, repo.Components...)
 			application.Repositories = append(application.Repositories, repo)
 

--- a/internal/konflux/config_generator.go
+++ b/internal/konflux/config_generator.go
@@ -10,12 +10,14 @@ import (
 	"strings"
 )
 
-func GenerateConfig(application Application, dryRun bool) error {
+func GenerateConfig(application Application, dryRun, generateTekton bool) error {
 	if err := generateKonfluxConfig(application); err != nil {
 		return err
 	}
-	if err := generateRepositoryConfig(application, dryRun); err != nil {
-		return err
+	if generateTekton {
+		if err := generateRepositoryConfig(application, dryRun); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -189,7 +191,6 @@ func generateKonfluxApplication(application Application, targetDir string) error
 		for env, _ := range releaseEnvironments {
 			rpaFile := fmt.Sprintf("%s-%s-%s-%s.yaml", application.Config.Product, hyphenize(application.Release.Version), application.ShortName, env)
 			rpaCdnFile := fmt.Sprintf("%s-%s-%s-%s-%s.yaml", application.Config.Product, hyphenize(application.Release.Version), application.ShortName, "cdn", env)
-			releasePlanFile := fmt.Sprintf("%s-%s-%s-%s-rp.yaml", application.Config.Product, hyphenize(application.Release.Version), application.ShortName, env)
 			templateData := struct {
 				Application // Embedded (no field name)
 				Env         string
@@ -200,15 +201,19 @@ func generateKonfluxApplication(application Application, targetDir string) error
 			if err := generateFileFromTemplate(templateFile, templateData, filepath.Join(rpaTargetDir, rpaFile), application); err != nil {
 				return err
 			}
-			if application.ShortName == "core" {
-				if err := generateFileFromTemplate("release-plan-admission-cdn.yaml", templateData, filepath.Join(rpaTargetDir, rpaCdnFile), application); err != nil {
-					return err
-				}
-			}
+			releasePlanFile := fmt.Sprintf("%s-%s-%s-%s-rp.yaml", application.Config.Product, hyphenize(application.Release.Version), application.ShortName, env)
 			if err := generateFileFromTemplate("release-plan-managed.yaml", templateData, filepath.Join(targetDir, releasePlanFile), application); err != nil {
 				return err
 			}
-
+			if application.ShortName == "core" {
+				cdnReleasePlanFile := fmt.Sprintf("%s-%s-%s-%s-%s-rp.yaml", application.Config.Product, hyphenize(application.Release.Version), application.ShortName, "cdn", env)
+				if err := generateFileFromTemplate("release-plan-admission-cdn.yaml", templateData, filepath.Join(rpaTargetDir, rpaCdnFile), application); err != nil {
+					return err
+				}
+				if err := generateFileFromTemplate("release-plan-cdn.yaml", templateData, filepath.Join(targetDir, cdnReleasePlanFile), application); err != nil {
+					return err
+				}
+			}
 		}
 
 	}

--- a/internal/konflux/templates/konflux/release-plan-cdn.yaml
+++ b/internal/konflux/templates/konflux/release-plan-cdn.yaml
@@ -27,7 +27,7 @@ spec:
         for defining CI/CD pipelines that are portable across Kubernetes distributions.
       description: "The {{ .Release.FullVersion | trimPrefix "v" }} release of Red Hat OpenShift Pipelines Operator."
       topic: |
-        The {{ .Release.FullVersion | trimPrefix "v" }} GA release of Red Hat OpenShift Pipelines Operator..
+        The {{ .Release.FullVersion | trimPrefix "v" }} GA release of Red Hat OpenShift Pipelines Operator.
         For more details see [product documentation](https://docs.redhat.com/en/documentation/red_hat_openshift_pipelines).
       synopsis: "Red Hat OpenShift Pipelines Release {{ .Release.FullVersion | trimPrefix "v" }}"
 

--- a/internal/konflux/templates/konflux/release-plan-cdn.yaml
+++ b/internal/konflux/templates/konflux/release-plan-cdn.yaml
@@ -1,0 +1,33 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: "false"
+    release.appstudio.openshift.io/standing-attribution: "true"
+    release.appstudio.openshift.io/releasePlanAdmission: {{.Config.Product}}-{{.Release.Version | hyphenize}}-{{.ShortName}}-cdn-{{.Env}}
+  name: {{.Config.Product}}-{{.Release.Version | hyphenize}}-{{.ShortName}}-cdn-{{.Env}}-rp
+spec:
+  application: {{.Name | hyphenize}}-{{hyphenize .Release.Version}}
+  target: rhtap-releng-tenant
+  data:
+    mapping:
+      defaults:
+        contentGateway:
+          productVersionName: "{{ .Release.FullVersion | trimPrefix "v" }}"
+    releaseNotes:
+      references:
+        - "https://docs.redhat.com/en/documentation/red_hat_openshift_pipelines"
+      type: "RHEA"
+      solution: |
+        Red Hat OpenShift Pipelines is a cloud-native, continuous integration and
+        continuous delivery (CI/CD) solution based on Kubernetes resources.
+        It uses Tekton building blocks to automate deployments across multiple
+        platforms by abstracting away the underlying implementation details.
+        Tekton introduces a number of standard custom resource definitions (CRDs)
+        for defining CI/CD pipelines that are portable across Kubernetes distributions.
+      description: "The {{ .Release.FullVersion | trimPrefix "v" }} release of Red Hat OpenShift Pipelines Operator."
+      topic: |
+        The {{ .Release.FullVersion | trimPrefix "v" }} GA release of Red Hat OpenShift Pipelines Operator..
+        For more details see [product documentation](https://docs.redhat.com/en/documentation/red_hat_openshift_pipelines).
+      synopsis: "Red Hat OpenShift Pipelines Release {{ .Release.FullVersion | trimPrefix "v" }}"
+

--- a/internal/konflux/templates/konflux/release-plan.yaml
+++ b/internal/konflux/templates/konflux/release-plan.yaml
@@ -22,6 +22,6 @@ spec:
           value: pipelines/release-pipeline.yaml
     params:
       - name: release_version
-        value: "{{.Release.ReleaseTag}}"
+        value: "{{- if or (eq .Release.Version \"nightly\") (eq .Release.Version \"next\") -}}{{ .Release.ReleaseTag }}{{- else -}}{{ .Release.FullVersion }}{{- end -}}"
       - name: release_to_github
         value: "{{.ReleaseToGitHub}}"

--- a/internal/konflux/templates/konflux/release-plan.yaml
+++ b/internal/konflux/templates/konflux/release-plan.yaml
@@ -22,6 +22,6 @@ spec:
           value: pipelines/release-pipeline.yaml
     params:
       - name: release_version
-        value: "{{.Release.FullVersion}}"
+        value: "{{.Release.ReleaseTag}}"
       - name: release_to_github
         value: "{{.ReleaseToGitHub}}"


### PR DESCRIPTION
This will allow to generate the konflux configuration in advance and apply on konflux before tekton PRs are generated Otherwise  for new releases tekton PRs always fail because of missing konflux configuration
Also update the releaseTag in releasePlans