### PR TITLE
Revert "update the release tag to latest osp patch release"

### DIFF
--- a/config/downstream/releases/1.23.yaml
+++ b/config/downstream/releases/1.23.yaml
@@ -1,5 +1,5 @@
 version: 1.23
-release-tag: 1.23.2
+release-tag: 1.23.0
 image-suffix: "-rhel9"
 code-freeze: false
 branches:


### PR DESCRIPTION
This reverts commit 2dc9e889bb6d1facd0092de0208130d3d2ca3bce.