### PR TITLE
Fix patch version increment in release automation

### DIFF
--- a/hack/common-functions.sh
+++ b/hack/common-functions.sh
@@ -68,7 +68,7 @@ function create-new-patch() {
       next_version="${RELEASE_VERSION}.0-RC-1"
     else
       last_num=$(echo "${release_tag}" | grep --only-matching "[0-9]\+$")
-      base_version=$(echo "${release_tag}" | grep -v --only-matching "[0-9]\+$")
+      base_version=$(echo "${release_tag}" | sed "s/[0-9]\+$//")
       next_version="${base_version}$((last_num + 1))"
     fi
   else


### PR DESCRIPTION
The create-new-patch function was failing when incrementing patch versions because it used 'grep -v --only-matching' which doesn't work as intended. The -v flag inverts matches and doesn't combine properly with --only-matching.

Changed to use 'sed' to remove the trailing number from the version string, which correctly extracts the base version (e.g., "1.22." from "1.22.2").

This fixes the automation failure for patch releases like 1.22.