### PR TITLE
update upstream branches for console-plugin

### DIFF
--- a/config/downstream/releases/next.yaml
+++ b/config/downstream/releases/next.yaml
@@ -33,4 +33,8 @@ branches:
     upstream: release-v0.1.x
   multicluster-proxy-aae:
     upstream: release-v0.1.x
+  console-plugin:
+    upstream: master
+  console-plugin-pf5:
+    upstream: release-v1.22.x
 release-tag: next

--- a/config/downstream/releases/nightly.yaml
+++ b/config/downstream/releases/nightly.yaml
@@ -5,3 +5,10 @@ code-freeze: false
 docker-file-options:
   args:
     GO_BUILDER: "registry.access.redhat.com/ubi10/go-toolset:latest"
+    NJS_BUILDER: "registry.access.redhat.com/ubi10/nodejs-24:latest"
+    NGX_RUNTIME: "registry.access.redhat.com/ubi10/nginx-126:latest"
+branches:
+  console-plugin-pf5:
+    upstream: main
+  console-plugin:
+    upstream: master


### PR DESCRIPTION
### update upstream branches for  console-plugin
Next Will use upstream breanches like this
```
  console-plugin:
    upstream: master
  console-plugin-pf5:
    upstream: release-v1.22.x
```
And nightly will use like this
```
  console-plugin-pf5:
    upstream: main
  console-plugin:
    upstream: master
```