### PR TITLE
Remove OCP 4.17 Configuration as its EOL as of today

### DIFF
--- a/config/downstream/applications/fbc.yaml
+++ b/config/downstream/applications/fbc.yaml
@@ -7,9 +7,6 @@
 - name: openshift-pipelines-index-4.16
   repos:
     - operator-index-4.16
-- name: openshift-pipelines-index-4.17
-  repos:
-    - operator-index-4.17
 - name: openshift-pipelines-index-4.18
   repos:
     - operator-index-4.18

--- a/config/downstream/repos/operator-index-4.17.yaml
+++ b/config/downstream/repos/operator-index-4.17.yaml
@@ -1,8 +1,0 @@
-name: operator
-prefetch-input: "NONE"
-components:
-  - name: index-4.17
-    nudges: [ "" ]
-    no-image-suffix: true
-tekton:
-  watched-sources: ( ".konflux/olm-catalog/index/***".pathChanged())


### PR DESCRIPTION
https://access.redhat.com/support/policy/updates/openshift