### PR TITLE
feat(slack): exclude noisy workflows from failure alerts

### DIFF
--- a/config/downstream/repos/operator.yaml
+++ b/config/downstream/repos/operator.yaml
@@ -8,6 +8,8 @@ components:
     no-image-suffix: true
   - name: webhook
   - name: proxy
+excluded-slack-alert-workflows:
+  - render-olm-catalog
 patches: []
 github:
   update-sources: |

--- a/internal/konflux/config.go
+++ b/internal/konflux/config.go
@@ -49,10 +49,11 @@ type Repository struct {
 	Patches          []Patch
 	NoPrefixUpstream bool     `json:"no-prefix-upstream" yaml:"no-prefix-upstream"`
 	UsePatchBranch   bool     `json:"use-patch-branch" yaml:"use-patch-branch"`
-	Owners           []string `json:"owners" yaml:"owners"`
-	PrefetchInput    string   `json:"prefetch-input" yaml:"prefetch-input"`
-	MinVersion       string   `json:"min-version" yaml:"min-version"`
-	MaxVersion       string   `json:"max-version" yaml:"max-version"`
+	Owners                 []string `json:"owners" yaml:"owners"`
+	ExcludedSlackWorkflows []string `json:"excluded-slack-alert-workflows" yaml:"excluded-slack-alert-workflows"`
+	PrefetchInput          string   `json:"prefetch-input" yaml:"prefetch-input"`
+	MinVersion             string   `json:"min-version" yaml:"min-version"`
+	MaxVersion             string   `json:"max-version" yaml:"max-version"`
 }
 type Branch struct {
 	Name           string

--- a/internal/konflux/templates/github/workflows/slack-notify-on-failure.yaml
+++ b/internal/konflux/templates/github/workflows/slack-notify-on-failure.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
-    if: {{ "${{ github.event.workflow_run.conclusion == 'failure' }}" }}
+    if: {{ "${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.name != 'auto-merge-upstream'" }}{{ range .ExcludedSlackWorkflows }} && github.event.workflow_run.name != '{{ . }}'{{ end }}{{ " }}" }}
     steps:
       - name: Send Slack notification
         uses: slackapi/slack-github-action@v2.1.0


### PR DESCRIPTION
Skip auto-merge-upstream for all repos and render-olm-catalog for operator to reduce Slack notification noise.


Assisted-by: Opus 4.6 (via Cursor)