### PR TITLE
update tge RPA template to use custom ECP policy

### DIFF
--- a/internal/konflux/templates/konflux/release-plan-admission.yaml
+++ b/internal/konflux/templates/konflux/release-plan-admission.yaml
@@ -1,5 +1,8 @@
 {{- $dot := .}}
 {{- $policy := "registry-standard" -}}
+{{- if eq .Config.Namespace "tekton-ecosystem-tenant" -}}
+  {{- $policy = "registry-tekton-ecosystem" -}}
+{{- end -}}
 {{- $intention := "production"}}
 {{- $serviceAccountName := "release-registry-prod" }}
 {{- $registry := "registry.redhat.io/openshift-pipelines" -}}


### PR DESCRIPTION
Update release-plan-admission template to use registry-tekton-ecosystem-{env} policy instead of registry-standard-{env} when the namespace is tekton-ecosystem-tenant.