### PR TITLE
Remove index-4.17 from operator-index component list

### DIFF
--- a/config/downstream/repos/operator-index.yaml
+++ b/config/downstream/repos/operator-index.yaml
@@ -18,9 +18,6 @@ components:
   - name: index-4.18
     nudges: [ "" ]
     no-image-suffix: true
-  - name: index-4.17
-    nudges: [ "" ]
-    no-image-suffix: true
   - name: index-4.16
     nudges: [ "" ]
     no-image-suffix: true


### PR DESCRIPTION
## Summary

- Removes `index-4.17` from the operator-index component list
- OCP 4.17 has reached EOL and the Konflux Component CR + tenant config have already been removed
- The ds-operator cleanup is in openshift-pipelines/operator#25224

## Note

There's also a duplicate `index-4.19` entry in this file (pre-existing, not introduced here).
