### PR TITLE
chore: use registry-tekton-ecosystem-stage policy for 1.23 bundle sta…

### DIFF
--- a/.konflux/config/kflux-prd-rh02.0fk9.p1/product/ReleasePlanAdmission/tekton-ecosystem/openshift-pipelines-1-23-bundle-stage.yaml
+++ b/.konflux/config/kflux-prd-rh02.0fk9.p1/product/ReleasePlanAdmission/tekton-ecosystem/openshift-pipelines-1-23-bundle-stage.yaml
@@ -14,7 +14,7 @@ spec:
   applications:
     - openshift-pipelines-bundle-1-23
   origin: tekton-ecosystem-tenant
-  policy: registry-standard-stage
+  policy: registry-tekton-ecosystem-stage
   data:
     releaseNotes:
       product_id: [ 604 ]


### PR DESCRIPTION
Switch the bundle stage RPA from registry-standard-stage to registry-tekton-ecosystem-stage ECP which handles the allowed_olm_image_registry_prefixes and stage-specific exclusions.