### PR TITLE
fix(slack): alert pipelines-rc for auto-merge-upstream failures

### DIFF
--- a/internal/konflux/templates/github/workflows/slack-notify-on-failure.yaml
+++ b/internal/konflux/templates/github/workflows/slack-notify-on-failure.yaml
@@ -15,7 +15,63 @@ jobs:
     runs-on: ubuntu-latest
     if: {{ "${{ github.event.workflow_run.conclusion == 'failure' }}" }}
     steps:
+      - name: Send Slack notification for auto-merge-upstream
+        if: {{ "${{ github.event.workflow_run.name == 'auto-merge-upstream' }}" }}
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: {{ "${{ secrets.SLACK_WEBHOOK_URL }}" }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "🔴 Workflow Failure: {{ "${{ github.event.workflow_run.name }}" }} in {{ "${{ github.event.workflow_run.repository.name }}" }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Repository:*\n{{ "${{ github.event.workflow_run.repository.full_name }}" }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n{{ "${{ github.event.workflow_run.name }}" }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\n{{ "${{ github.event.workflow_run.head_branch }}" }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<!subteam^S04NUBJ20RG> please investigate and fix this failure.\nReach out to the release captain if you need assistance."
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Run"
+                      },
+                      "url": "{{ "${{ github.event.workflow_run.html_url }}" }}"
+                    }
+                  ]
+                }
+              ]
+            }
       - name: Send Slack notification
+        if: {{ "${{ github.event.workflow_run.name != 'auto-merge-upstream' }}" }}
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: {{ "${{ secrets.SLACK_WEBHOOK_URL }}" }}


### PR DESCRIPTION
Route auto-merge-upstream workflow failure notifications to the release captain group instead of component owners.


Assisted-by: Claude Opus 4.6 (via Cursor)