### PR TITLE
fix(konflux): derive CPE label RHEL version from image-suffix

### DIFF
--- a/internal/konflux/dockerfile_utils.go
+++ b/internal/konflux/dockerfile_utils.go
@@ -194,7 +194,7 @@ func getDockerFileLabels(component Component) map[string]string {
 		"io.k8s.description":   fmt.Sprintf("Red Hat OpenShift Pipelines %s %s", component.Repository.Name, component.Name),
 		"io.k8s.display-name":  fmt.Sprintf("Red Hat OpenShift Pipelines %s %s", component.Repository.Name, component.Name),
 		"io.openshift.tags":    fmt.Sprintf("tekton,openshift,%s,%s", component.Repository.Name, component.Name),
-		"cpe":                  fmt.Sprintf("cpe:/a:redhat:openshift_pipelines:%s::el9", component.Version.Version),
+		"cpe":                  fmt.Sprintf("cpe:/a:redhat:openshift_pipelines:%s::%s", component.Version.Version, strings.TrimPrefix(component.Version.ImageSuffix, "-rh")),
 		// Add any others here...
 	}
 


### PR DESCRIPTION
## Problem

The Konflux managed release pipeline's `check-labels` task validates that
each container image's `cpe` label matches the `releaseNotes.cpe` value
from the ReleasePlanAdmission (RPA).

For **1.15** (the only version with `image-suffix: -rhel8`), this check
fails because:

- **RPA on cluster** (correctly derived from `image-suffix`):
  `cpe:/a:redhat:openshift_pipelines:1.15::el8`
- **Image labels** (hardcoded in Dockerfile generation):
  `cpe:/a:redhat:openshift_pipelines:1.15::el9`

This blocks **all** stage and production releases for 1.15 — both core
and bundle releases fail at the `check-labels` task with:

```
task check-labels failed: "step-check-labels" exited with code 1: Error
task check-labels failed: "step-enforce-name-label" exited with code 1: Error
```

The validation script (`check_labels.py` in `konflux-ci/release-service-utils`)
compares the image's `cpe` label against `releaseNotes.cpe` from the merged
RP + RPA data, and raises `LabelValidationError` on mismatch when `enforce=true`.

### Evidence

The RPA template already derives `rhel_target` correctly:
```yaml
# internal/konflux/templates/konflux/release-plan-admission.yaml
rhel_target: {{.Application.Release.ImageSuffix | trimPrefix "-rh"}}
```

But the Dockerfile generation hardcodes `el9`:
```go
// internal/konflux/dockerfile_utils.go (before this fix)
"cpe": fmt.Sprintf("cpe:/a:redhat:openshift_pipelines:%s::el9", component.Version.Version),
```

### Versions affected

| Version | image-suffix | Dockerfile CPE | RPA CPE | Match? |
|---------|-------------|----------------|---------|--------|
| 1.15    | `-rhel8`    | `::el9`        | `::el8` | **NO** |
| 1.20    | `-rhel9`    | `::el9`        | `::el9` | yes    |
| 1.21    | `-rhel9`    | `::el9`        | `::el9` | yes    |
| 1.22    | `-rhel9`    | `::el9`        | `::el9` | yes    |
| 1.23    | `-rhel9`    | `::el9`        | `::el9` | yes    |

Only 1.15 is affected. All other versions produce the same output after
this change.

## Fix

Derive the RHEL version from `component.Version.ImageSuffix` using the
same `strings.TrimPrefix("-rh")` logic as the RPA template, instead of
hardcoding `el9`.

## After merge

1. `generate-konflux` workflow runs automatically on push to `main`
2. Bot creates Dockerfile update PRs on each component repo's `release-v1.15.x`
3. Konflux rebuilds images with correct CPE labels
4. Stage/prod releases pass `check-labels`