### PR TITLE
remove hub refernces from 1.24 rpa

### DIFF
--- a/.konflux/konflux-release-data/config/kflux-prd-rh02.0fk9.p1/product/ReleasePlanAdmission/tekton-ecosystem/openshift-pipelines-1-24-core-prod.yaml
+++ b/.konflux/konflux-release-data/config/kflux-prd-rh02.0fk9.p1/product/ReleasePlanAdmission/tekton-ecosystem/openshift-pipelines-1-24-core-prod.yaml
@@ -102,18 +102,6 @@ spec:
           repositories:
             - url: "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9"
           pushSourceContainer: true
-        - name: tektoncd-hub-1-24-api
-          repositories:
-            - url: "registry.redhat.io/openshift-pipelines/pipelines-hub-api-rhel9"
-          pushSourceContainer: true
-        - name: tektoncd-hub-1-24-db-migration
-          repositories:
-            - url: "registry.redhat.io/openshift-pipelines/pipelines-hub-db-migration-rhel9"
-          pushSourceContainer: true
-        - name: tektoncd-hub-1-24-ui
-          repositories:
-            - url: "registry.redhat.io/openshift-pipelines/pipelines-hub-ui-rhel9"
-          pushSourceContainer: true
         - name: tektoncd-pipeline-1-24-controller
           repositories:
             - url: "registry.redhat.io/openshift-pipelines/pipelines-controller-rhel9"

--- a/.konflux/konflux-release-data/config/kflux-prd-rh02.0fk9.p1/product/ReleasePlanAdmission/tekton-ecosystem/openshift-pipelines-1-24-core-stage.yaml
+++ b/.konflux/konflux-release-data/config/kflux-prd-rh02.0fk9.p1/product/ReleasePlanAdmission/tekton-ecosystem/openshift-pipelines-1-24-core-stage.yaml
@@ -102,18 +102,6 @@ spec:
           repositories:
             - url: "registry.stage.redhat.io/openshift-pipelines/pipelines-git-init-rhel9"
           pushSourceContainer: true
-        - name: tektoncd-hub-1-24-api
-          repositories:
-            - url: "registry.stage.redhat.io/openshift-pipelines/pipelines-hub-api-rhel9"
-          pushSourceContainer: true
-        - name: tektoncd-hub-1-24-db-migration
-          repositories:
-            - url: "registry.stage.redhat.io/openshift-pipelines/pipelines-hub-db-migration-rhel9"
-          pushSourceContainer: true
-        - name: tektoncd-hub-1-24-ui
-          repositories:
-            - url: "registry.stage.redhat.io/openshift-pipelines/pipelines-hub-ui-rhel9"
-          pushSourceContainer: true
         - name: tektoncd-pipeline-1-24-controller
           repositories:
             - url: "registry.stage.redhat.io/openshift-pipelines/pipelines-controller-rhel9"


### PR DESCRIPTION
Removes tektoncd-hub image entries from core-prod and core-stage rpa files to avoid release failures when Konflux looks for hub images that won't be built.